### PR TITLE
Show statistics link for tutors in task_detail

### DIFF
--- a/src/templates/tasks/task_detail.html
+++ b/src/templates/tasks/task_detail.html
@@ -16,8 +16,6 @@
 <p>
 {% if user|in_group:"Tutor" or user|in_group:"Trainer"%}
 	<span class="icon ui-icon-triangle-1-e"></span><a href={% url attestation_list task_id=task.id%}>{% trans "Attestations" %}</a>
-{% endif %}
-{% if user|in_group:"Trainer"%}
 	<span class="icon ui-icon-triangle-1-e"></span><a href={% url statistics task_id=task.id%}>{% trans "Statistics"%}</a>
 {% endif %}
 {% if user|in_group:"User"%}


### PR DESCRIPTION
Currently, the statistics link is visible for tutors in task_list, but not in task_detail.
This change would make the visibility more consistent.
