### PR TITLE
Added upper limits to required django packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ Markdown>=2.2.1
 Pygments>=1.6rc1
 South>=0.7.6
 chardet>=2.1.1
-django-extensions>=1.0.3
-django-tinymce>=1.5.1b4
+django-extensions>=1.0.3,<1.3.0
+django-tinymce>=1.5.1b4,<1.6.0
 docutils>=0.10
 subprocess32
 psycopg2


### PR DESCRIPTION
There have to be upper limits to the versions of django-extensions and django-tinymce because we are using an outdated django (1.3.7). The new versions of django-extensions do no longer run with that django version.
