### PR TITLE
Fixed a problem in the LineCounter checker.

### DIFF
--- a/src/checker/checker/LineCounter.py
+++ b/src/checker/checker/LineCounter.py
@@ -113,12 +113,12 @@ class LineCounter(Checker):
 				log = log + "Line Width Checker (l 178): ZeroDivisionError " + \
 					  " (no comment / code / coco lines in file!)"
 			
-            lines = lines + lines_in_file
-            comment_lines = comment_lines + comment_lines_in_file
-            code_lines = code_lines + code_lines_in_file
-            coco_lines = coco_lines + coco_lines_in_file
+			lines = lines + lines_in_file
+			comment_lines = comment_lines + comment_lines_in_file
+			code_lines = code_lines + code_lines_in_file
+			coco_lines = coco_lines + coco_lines_in_file
 
-        # All files have been processed.
+		# All files have been processed.
 		try:
 			log = log + ("<br>" + `files` + " Dateien, "
 						 + `lines` + " Zeilen, davon "


### PR DESCRIPTION
The lines adding the statistics for a file were wrongly indented which caused a) wrong statistics and b) crashes.
