### PR TITLE
CSV files should use commas, not semicolons.

### DIFF
--- a/src/templates/attestation/rating_export.csv
+++ b/src/templates/attestation/rating_export.csv
@@ -1,3 +1,3 @@
-{{byte_order_marker}}"First Name";"Last Name";"Mat";"eMail";"Final grade";{% for task in task_list %}"{{task|addslashes}}";{% endfor %}
-{% for user_row in rating_list %}{% for attestation in user_row %}{% if forloop.first %}"{{attestation.first_name|addslashes}}";"{{attestation.last_name|addslashes}}";"{{attestation.mat_number|addslashes}}";"{{attestation.email|addslashes}}";"{{attestation.final_grade|addslashes}}";{% else %}"{{attestation.final_grade|addslashes }}";{% endif %}{% endfor %}
+{{byte_order_marker}}"First Name","Last Name","Mat","eMail","Final grade",{% for task in task_list %}"{{task|addslashes}}",{% endfor %}
+{% for user_row in rating_list %}{% for attestation in user_row %}{% if forloop.first %}"{{attestation.first_name|addslashes}}","{{attestation.last_name|addslashes}}","{{attestation.mat_number|addslashes}}","{{attestation.email|addslashes}}","{{attestation.final_grade|addslashes}}",{% else %}"{{attestation.final_grade|addslashes }}",{% endif %}{% endfor %}
 {% endfor %}


### PR DESCRIPTION
The current export to csv uses semicolons to separate the values which causes the automatic import to fail. It is better to use commas instead.