### PR TITLE
add mime type for Isabelle theory files

### DIFF
--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -329,7 +329,8 @@ def load_defaults(settings):
 
     d.MIMETYPE_ADDITIONAL_EXTENSIONS = \
         [("text/plain",".properties"),
-         ("text/x-r-script",".R")]
+         ("text/x-r-script",".R"),
+         ("text/plain",".thy")]
 
     # Subclassed TestSuitRunner to prepopulate unit test database.
     d.TEST_RUNNER = 'utilities.TestSuite.TestSuiteRunner'


### PR DESCRIPTION
Otherwise Praktomat doesn't recognize files with the extension ".thy", therefore rejecting solution uploads to Isabelle exercises.