### PR TITLE
Moved the ‘Attest next solution’ button up

### DIFF
--- a/src/templates/attestation/attestation_list.html
+++ b/src/templates/attestation/attestation_list.html
@@ -79,6 +79,15 @@
 	{% else %}
 	
 		<div id="Solutions">
+
+			{% if user.is_tutor %}
+				<h2>{% trans "Attestation Progress" %}</h2>
+				<p>{{ unattested_solutions|length }} solutions to attest.</p>
+				<div>
+					<input id="next_attestation_button" type="button" value="Attest next solution" {% if unattested_solutions|l\
+ength == 0 %}disabled="disabled"{% endif %} onclick="location.href ='{% url "new_attestation_for_task" task_id=task.id %}'"/>
+				</div>
+			{% endif %}
 			
 			{% if user.is_trainer %}
 				<h2>{% trans "Attestation Progress by Tutor" %}</h2>

--- a/src/templates/attestation/attestation_list.html
+++ b/src/templates/attestation/attestation_list.html
@@ -84,8 +84,7 @@
 				<h2>{% trans "Attestation Progress" %}</h2>
 				<p>{{ unattested_solutions|length }} solutions to attest.</p>
 				<div>
-					<input id="next_attestation_button" type="button" value="Attest next solution" {% if unattested_solutions|l\
-ength == 0 %}disabled="disabled"{% endif %} onclick="location.href ='{% url "new_attestation_for_task" task_id=task.id %}'"/>
+					<input id="next_attestation_button" type="button" value="Attest next solution" {% if unattested_solutions|length == 0 %}disabled="disabled"{% endif %} onclick="location.href ='{% url "new_attestation_for_task" task_id=task.id %}'"/>
 				</div>
 			{% endif %}
 			


### PR DESCRIPTION
Moved the ‘Attest next solution’ button up so that a tutor can go to the next solution without scrolling.

The current location of the 'Attest next solution' button is at the end of the page so that a tutor has to scroll to reach it. This patch moves it upwards so that a tutor does not need to scroll, thus making attestation faster.

Is is actually a copy as the old location is not deleted.