### PR TITLE
Task-Admin-Feature: additional actions avoid working via dbshell

### DIFF
--- a/src/tasks/admin.py
+++ b/src/tasks/admin.py
@@ -44,7 +44,7 @@ class TaskAdmin(admin.ModelAdmin):
 	date_hierarchy = 'publication_date'
 	save_on_top = True
 	inlines = [MediaInline] + CheckerInline.__subclasses__() + [ RatingAdminInline]
-	actions = ['export_tasks', 'run_all_checkers', 'run_all_checkers_on_finals', 'run_all_checkers_on_latest_only_failed']
+	actions = ['export_tasks', 'run_all_checkers', 'run_all_checkers_on_finals', 'run_all_checkers_on_latest_only_failed', 'delete_attestations', 'unset_all_checker_finished', 'run_all_uploadtime_checkers_on_all']
 	
 	formfield_overrides = {
         models.TextField: {'widget': TinyMCE()},
@@ -107,6 +107,112 @@ class TaskAdmin(admin.ModelAdmin):
 		""" Rerun all checker including "not always" action for students with final or latest of only failed solutions """
 		self.run_all_checkers_on_finals(request, queryset)
 		self.run_all_checkers_on_latest_only_failed(request, queryset)
+	
+	def delete_attestations(self, request, queryset):
+		""" delete given attestations for task solutions """
+		from attestation.models import Attestation
+	  	start = timer()
+		count = 0
+		tcount = 0
+		for task in queryset:
+			solution_set = Solution.objects.filter(task=task.id)
+			for sol in solution_set :
+				for a in Attestation.objects.filter(solution=sol):
+					a.delete()
+					count += 1
+			tcount += 1
+		end = timer()
+		self.message_user(request, "Deleted %d Attestations over %d Tasks: LoopTimer: %d " %(count, tcount, end-start),"warning")
+
+
+	def run_all_uploadtime_checkers_on_all(self, request, queryset):
+		""" Rerun on all solutions all checkers which are running at uploadtime """
+		from checker.basemodels import check_multiple
+		from accounts.models import User
+		from django.template import Context, loader
+		from django.contrib.sites.requests import RequestSite
+		from django.conf import settings
+		from django.core.mail import send_mail
+		from django.utils.translation import ugettext_lazy as _
+		myRequestUser = User.objects.filter(id=request.user.id)
+		allstart = timer()
+	  	task_set = queryset
+		for task in task_set:
+			start = timer()
+			#solutions = Solution.objects.filter(task=task.id).order_by('author', 'number')			
+			solution_set = task.solution_set.order_by('author','number') 
+			
+			old_final_solution_set =  solution_set.filter(final=True)			
+			users_with_old_final_solution = list(set(old_final_solution_set.values('author').values_list('author',flat = True)))
+			
+			for solution in old_final_solution_set:
+				solution.final = False
+				solution.accepted = False
+				solution.save()
+			
+			#TODO: some how inform user how long time they must wait until this method will be finish. 
+			#print("rerun checkers ... wait much time ...")			
+			#this takes many time !!!!
+			if  solution_set.count() > 1 :
+				check_multiple(solution_set,False)  # just run upload-time_checkers  ... should we ignore Testuploads?
+			elif  solution_set.count() == 1 :
+				check_solution(latest_only_failed_solution,False)
+			
+			new_accepted_solution_set = Solution.objects.filter(task=task.id , accepted=True , testupload=False ).order_by('author', 'number')
+			users_with_accepted_solutions = list(set(
+							 new_accepted_solution_set.values('author').values_list('author', flat=True)
+							))
+			
+
+			for userid in users_with_accepted_solutions :
+				new_final_solution = new_accepted_solution_set.filter(author = userid).latest('number')
+				new_final_solution.final = True
+				new_final_solution.save()
+			
+			
+			new_final_solution_set =  new_accepted_solution_set.filter(final=True)
+			users_with_final_solution =  list(set(new_final_solution_set.values('author').values_list('author',flat = True)))  
+			
+			users_missing_in_new_final_solution = list(set(users_with_old_final_solution) - set(users_with_final_solution))
+			missing_users_in_new_final_solution_set = task.solution_set.filter(author__in=users_missing_in_new_final_solution).order_by('author','number') 	
+			
+			for userid in users_missing_in_new_final_solution :				
+				user = User.objects.filter(id=userid)
+				latestfailed_user_solution = missing_users_in_new_final_solution_set.filter(author=userid).latest('number') 
+				# Send final solution lost email to current RequestUser tutor/trainer/superuser
+				t = loader.get_template('solutions/submission_final_lost_email.html')
+				c = {
+					'protocol': request.is_secure() and "https" or "http",
+					'domain': RequestSite(request).domain, 
+					'site_name': settings.SITE_NAME,
+					'solution': latestfailed_user_solution,
+					'request_user': myRequestUser,
+				}
+				if request.user.email and latestfailed_user_solution.author.email:
+					send_mail(_("[%s] lost final submission confirmation") % settings.SITE_NAME, t.render(Context(c)), None, [request.user.email, latestfailed_user_solution.author.email])
+				elif request.user.email and not latestfailed_user_solution.author.email:
+					send_mail(_("[%s] lost final submission confirmation") % settings.SITE_NAME, t.render(Context(c)), None, [request.user.email])				  
+				elif not request.user.email and latestfailed_user_solution.author.email:
+					send_mail(_("%s lost final submission confirmation") % settings.SITE_NAME, t.render(Context(c)), None, [latestfailed_user_solution.author.email])					
+			end = timer()
+			self.message_user(request, "Task %s : Checked %d authors lost their finals: LoopTimer: %d seconds elapsed "%(task.title, len(users_missing_in_new_final_solution),(end-start)),"warning")
+		allend = timer()
+		self.message_user(request, "%d Tasks rechecked : LoopTimer: %d seconds elapsed" % (task_set.count(),allend-allstart))
+		
+
+		
+	def unset_all_checker_finished(self, request, queryset):
+		""" Unset task attribute: all_checker_finished """  
+	  	start = timer()
+		count = 0
+		for task in queryset:
+			task.all_checker_finished = False
+			task.save()
+			count += 1
+		end = timer()
+		self.message_user(request, "State of attribute \"all_checker_finished\" at %d Tasks resetted to \"FALSE\": LoopTimer: %d " % (count, end-start),"warning")
+		
+		
 
 
 	def get_urls(self):

--- a/src/tasks/admin.py
+++ b/src/tasks/admin.py
@@ -44,7 +44,7 @@ class TaskAdmin(admin.ModelAdmin):
 	date_hierarchy = 'publication_date'
 	save_on_top = True
 	inlines = [MediaInline] + CheckerInline.__subclasses__() + [ RatingAdminInline]
-	actions = ['export_tasks', 'run_all_checkers']
+	actions = ['export_tasks', 'run_all_checkers', 'run_all_checkers_on_finals', 'run_all_checkers_on_latest_only_failed']
 	
 	formfield_overrides = {
         models.TextField: {'widget': TinyMCE()},
@@ -65,16 +65,49 @@ class TaskAdmin(admin.ModelAdmin):
 		response = HttpResponse(Task.export_Tasks(queryset).read(), content_type="application/zip")
 		response['Content-Disposition'] = 'attachment; filename=TaskExport.zip'
 		return response
-		
+
 	
-	def run_all_checkers(self, request, queryset):
-		""" Rerun all checker including "not always" action """
+	def run_all_checkers_on_finals(self, request, queryset):
+		""" Rerun all checker on final solutions including "not always" action """
 		start = timer()
 		count = 0
 		for task in queryset:
 			count += task.check_all_final_solutions()
 		end = timer()
 		self.message_user(request, "%d final solutions were successfully checked (%d seconds elapsed)." % (count, end-start))
+
+
+	def run_all_checkers_on_latest_only_failed(self,request, queryset):
+		""" Rerun all checker on latest of only failed solutions including "not always" action """
+		from checker.basemodels import check_solution
+		from accounts.models import User
+		start = timer()
+		count = 0
+		for task in queryset:
+			solution_queryset = task.solution_set
+			final_solutions_queryset = solution_queryset.filter(final=True)
+			finalusers = list(set(final_solutions_queryset.values('author').values_list('author', flat=True)))
+			only_failed_solution_set = solution_queryset.exclude(author__in=finalusers)
+
+			nonfinalusers = list( set(User.objects.all().values('id').values_list('id',flat=True)) - set(finalusers))
+						
+			for user in User.objects.filter(id__in=nonfinalusers) :
+				users_only_failed_solution = only_failed_solution_set.filter(author=user).order_by('author','number') 
+				ucount = int(users_only_failed_solution.count())
+				if ucount :
+					latest_only_failed_solution=users_only_failed_solution.latest('number')
+					check_solution(latest_only_failed_solution,True)					
+					count += 1
+		end = timer()
+		self.message_user(request, "%d users with only failed solutions were checked (%d seconds elapsed)." % (count, end-start))
+
+
+
+	def run_all_checkers(self, request, queryset):
+		""" Rerun all checker including "not always" action for students with final or latest of only failed solutions """
+		self.run_all_checkers_on_finals(request, queryset)
+		self.run_all_checkers_on_latest_only_failed(request, queryset)
+
 
 	def get_urls(self):
 		""" Add URL to task import """

--- a/src/templates/solutions/submission_final_lost_email.html
+++ b/src/templates/solutions/submission_final_lost_email.html
@@ -1,0 +1,20 @@
+{% load i18n %}{% autoescape off %}{% trans "Hello " %}{{solution.author}},
+
+your previous final solution of task "{{solution.task}}" has failed after task-corrections. We are sorry for that.
+
+Sadly, you have to submit a new solution. 
+
+You can view your now last failed solution here: {{protocol}}://{{ domain }}{% url "solution_detail" solution_id=solution.id %}
+
+Your upload included these files:
+{% for file in solution.solutionfile_set.all %}
+	{% with file.get_signature as signature %}{{file}} [MD5:{{file.get_hash}}] {% if signature %}[SIGNATURE:{{signature}}]{% endif %} {% endwith%}
+{% endfor %}
+
+Please note that you have *not* completed the task yet.
+
+{% trans "Thanks for using our site!" %}
+
+{% blocktrans %}The {{ site_name }} team{% endblocktrans %}
+
+{% endautoescape %}


### PR DESCRIPTION
 Task-Admin: to prevend "repair functions" doing from dbshell and filesystem

            implemented missing functions
           - run_all_checkers (modificated like in AutoAttestChecker  commit https://github.com/ifrh/Praktomat/blob/0e6ec5d936eb292b63e73b7caf299b3efd9bfaa4/src/tasks/admin.py ; see pull request https://github.com/KITPraktomatTeam/Praktomat/pull/264 )
           - run_all_checkers_on_finals (its old name is run_all_checkers like in AutoAttestChecker commit)
           - run_all_checkers_on_latest_only_failed (like in AutoAttestChecker commit)
           - delete_attestations
           - run_all_uploadtime_checkers_on_all (usefull after some submissions used checkers hat to be changed including  send notification email if former "accepted" solution is not accepted any more)
           - unset_all_checker_finished