### PR TITLE
Only search for main entry point if required

### DIFF
--- a/src/checker/compiler/Builder.py
+++ b/src/checker/compiler/Builder.py
@@ -111,11 +111,12 @@ class Builder(Checker):
 		""" Build it. """
 		result = self.create_result(env)
 
-		# Try to find out the main modules name with only the source files present
-		try:
-			env.set_program(self.main_module(env))
-		except self.NotFoundError:
-			pass
+		if self._main_required:
+			# Try to find out the main modules name with only the source files present
+			try:
+				env.set_program(self.main_module(env))
+			except self.NotFoundError:
+				pass
 		
 		filenames = [name for name in self.get_file_names(env)]
 		args = [self.compiler()] + self.output_flags(env) + self.flags(env) + filenames + self.libs()
@@ -129,12 +130,12 @@ class Builder(Checker):
 		passed = not self.has_warnings(output)	
 		log  = self.build_log(output,args,set(filenames).intersection([solutionfile.path() for solutionfile in env.solution().solutionfile_set.all()]))
 
-		# Now that submission was successfully built, try to find the main modules name again
-		try:
-			if passed : env.set_program(self.main_module(env))
-		except self.NotFoundError as e:
-			# But only complain if the main method is required
-			if self._main_required:
+		if self._main_required:
+			# Now that submission was successfully built, try to find the main modules name again
+			try:
+				if passed : env.set_program(self.main_module(env))
+			except self.NotFoundError as e:
+				# But only complain if the main method is required
 				log += "<pre>" + str(e) + "</pre>"
 				passed = False
 


### PR DESCRIPTION
For the JAVA builder the process of determining the main class, is
quite time consuming. For example, in the "Database System Architecture
and Implementation" [1] searching for a main entry point in the long
list of java classes caused server timeouts.

Thus, only search for a main entry point, if that is required.

[1] https://cms.uni-konstanz.de/informatik/grossniklaus/education/archive/inf-20210/