### PR TITLE
Make mat_number a string field

### DIFF
--- a/src/accounts/migrations/0003_auto_20170512_0624.py
+++ b/src/accounts/migrations/0003_auto_20170512_0624.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import accounts.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0002_add_groups'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='mat_number',
+            field=models.CharField(blank=True, max_length=100, null=True, validators=[accounts.models.validate_mat_number]),
+        ),
+    ]

--- a/src/accounts/models.py
+++ b/src/accounts/models.py
@@ -23,7 +23,7 @@ def validate_mat_number(value):
 class User(BasicUser):
 	# all fields need to be null-able in order to create user
 	tutorial = models.ForeignKey('Tutorial', null=True, blank=True, help_text = _("The tutorial the student belongs to."))
-	mat_number = models.IntegerField( null=True, blank=True, validators=[validate_mat_number]) # special blank and unique validation in forms
+	mat_number = models.CharField(null=True, blank=True, max_length=100, validators=[validate_mat_number])  # special blank and unique validation in forms
 	final_grade = models.CharField( null=True, blank=True, max_length=100,  help_text = _('The final grade for the whole class.'))
 	programme = models.CharField(null=True, blank=True, max_length=100, help_text = _('The programme the student is enlisted in.'))
 	activation_key=models.CharField(_('activation key'), max_length=40, editable=False)

--- a/src/checker/migrations/0008_auto_20170512_0624.py
+++ b/src/checker/migrations/0008_auto_20170512_0624.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('checker', '0007_auto_20170429_2022'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='junitchecker',
+            name='ignore',
+            field=models.CharField(default=b'', help_text='space-seperated list of files to be ignored during compilation, i.e.: these files will not be compiled.', max_length=4096, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='scriptchecker',
+            name='filename',
+            field=models.CharField(help_text='What the file will be named in the sandbox. If empty, we try to guess the right filename!', max_length=500, blank=True),
+        ),
+    ]


### PR DESCRIPTION
For identity protection, some universities do not
provide the actual mat_number via shibboleth.
However, a unique mat_number of type integer is required.

Using a string field is more flexible and should not
yield to significant performance drops, since the
mat_number is nominal data.

Close #277