### PR TITLE
removing multiple ResourceWarnings "unclosed files". 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ install:
  - python --version && python -c "import sqlite3; print(\"... uses pysqlite \" + sqlite3.version +\" with SQLite \" + sqlite3.sqlite_version);"
 
 script:
+ - python -Wa ./src/manage-test.py test accounts attestation checker configuration solutions tasks
  - ./src/manage-test.py test accounts attestation checker configuration solutions tasks

--- a/src/checker/basemodels.py
+++ b/src/checker/basemodels.py
@@ -236,7 +236,9 @@ class CheckerResult(models.Model):
     def add_artefact(self, filename, path):
         assert os.path.isfile(path)
         artefact = CheckerResultArtefact(result = self, filename=filename)
-        artefact.file.save(filename, File(open(path, 'rb')))
+        fd = open(path, 'rb')
+        artefact.file.save(filename, File(fd))
+        fd.close()
 
 def get_checkerresultartefact_upload_path(instance, filename):
     result = instance.result

--- a/src/checker/checker/CreateFileChecker.py
+++ b/src/checker/checker/CreateFileChecker.py
@@ -33,7 +33,9 @@ class CheckerWithFile(Checker):
 
     def add_to_environment(self, env, path):
         if (self._add_to_environment):
-            env.add_source(path, open(os.path.join(env.tmpdir(), path), 'rb').read())
+            fd = open(os.path.join(env.tmpdir(), path), 'rb')
+            env.add_source(path, fd.read())
+            fd.close()
 
     def run_file(self, env):
         result = self.create_result(env)

--- a/src/checker/checker/DejaGnu.py
+++ b/src/checker/checker/DejaGnu.py
@@ -134,11 +134,15 @@ class DejaGnuTester(Checker, DejaGnu):
         output = encoding.get_unicode(output)
 
         try:
-            summary = encoding.get_unicode(open(os.path.join(testsuite, program_name + ".sum"),"rb").read())
-            log        = encoding.get_unicode(open(os.path.join(testsuite, program_name + ".log"),"rb").read())
+            fd_summary = open(os.path.join(testsuite, program_name + ".sum"),"rb")
+            summary = encoding.get_unicode(fd_summary.read())
+            fd_summary.close()
+            fd_log = open(os.path.join(testsuite, program_name + ".log"),"rb")
+            log     = encoding.get_unicode(fd_log.read())
+            fd_log.close()
         except:
             summary = ""
-            log        = ""
+            log     = ""
 
         complete_output = self.htmlize_output(output + log)
 

--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -188,7 +188,7 @@ class TestChecker(TestCase):
                 self.assertFalse(checkerresult.passed, "Test succeed (no timeout?)")
                 self.assertNotIn('done', checkerresult.log, "Test did finish (no timeout?)")
 
-
+    #@unittest.skipIf('WSL_DISTRO_NAME' in os.environ, "in MS Windows 10 - WSL something is wrong")
     @unittest.skipIf('TRAVIS' in os.environ, "ulimit doesn’t seem to work on travis")
     @unittest.skipIf(settings.USESAFEDOCKER, "not yet supported with safe-docker")
     def test_script_filesizelimit(self):
@@ -305,9 +305,10 @@ class TestChecker(TestCase):
 
     def test_r_checker(self):
         solution_file = SolutionFile(solution = self.solution)
+        fd = open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',))
         solution_file.file.save(
             'example.R',
-            File(open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)))
+            File(fd)
             )
 
         RChecker.RChecker.objects.create(
@@ -322,14 +323,15 @@ class TestChecker(TestCase):
             self.assertTrue(checkerresult.artefacts.exists())
             self.assertEqual(checkerresult.artefacts.get().path(), "Rplots.pdf")
             self.assertTrue(checkerresult.passed, checkerresult.log)
-
+        fd.close()
         solution_file.delete()
 
     def test_r_checker_2(self):
         solution_file = SolutionFile(solution = self.solution)
+        fd = open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',))
         solution_file.file.save(
             'example.R',
-            File(open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)))
+            File(fd)
             )
 
         RChecker.RChecker.objects.create(
@@ -345,13 +347,15 @@ class TestChecker(TestCase):
             self.assertTrue(checkerresult.passed, checkerresult.log)
             self.assertTrue(checkerresult.artefacts.exists())
             self.assertEqual(checkerresult.artefacts.get().path(), "Rplots.pdf")
+        fd.close()
         solution_file.delete()
 
     def test_r_checker_3(self):
         solution_file = SolutionFile(solution = self.solution)
+        fd = open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',))
         solution_file.file.save(
             'example.R',
-            File(open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)))
+            File(fd)
             )
 
         RChecker.RChecker.objects.create(
@@ -365,18 +369,21 @@ class TestChecker(TestCase):
         for checkerresult in self.solution.checkerresult_set.all():
             self.assertIn('Could not find expected R script', checkerresult.log, "Test did not complain (%s)" % checkerresult.log)
             self.assertFalse(checkerresult.passed, checkerresult.log)
+        fd.close()
         solution_file.delete()
 
     def test_r_checker_4(self):
         solution_file = SolutionFile(solution = self.solution)
+        fd1 = open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',))
         solution_file.file.save(
             'example.R',
-            File(open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)))
+            File(fd1)
             )
         solution_file2 = SolutionFile(solution = self.solution)
+        fd2 = open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',))
         solution_file2.file.save(
             'example2.R',
-            File(open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)))
+            File(fd2)
             )
 
         RChecker.RChecker.objects.create(
@@ -389,6 +396,8 @@ class TestChecker(TestCase):
         for checkerresult in self.solution.checkerresult_set.all():
             self.assertIn('Multiple R scripts found', checkerresult.log, "Test did not complain (%s)" % checkerresult.log)
             self.assertFalse(checkerresult.passed, checkerresult.log)
+        fd1.close()
+        fd2.close()
         solution_file2.delete()
 
     def test_keep_file_checker(self):

--- a/src/solutions/tests.py
+++ b/src/solutions/tests.py
@@ -28,6 +28,7 @@ class TestViews(TestCase):
                             'solutionfile_set-TOTAL_FORMS': '3',
                             'solutionfile_set-0-file': f
                         }, follow=True)
+        f.close()
         self.assertRedirectsToView(response, 'solution_detail')
 
     def test_post_solution_expired(self):
@@ -41,6 +42,7 @@ class TestViews(TestCase):
                             'solutionfile_set-TOTAL_FORMS': '3',
                             'solutionfile_set-0-file': f
                         }, follow=True)
+        f.close()
         self.assertEqual(response.status_code, 403)
 
     def test_get_solution(self):

--- a/src/tasks/tests.py
+++ b/src/tasks/tests.py
@@ -41,6 +41,7 @@ class TestStaffViews(TestCase):
         response = self.client.post(reverse('admin:task_import'), data={
                             'file': f
                         }, follow=True)
+        f.close()
         self.assertRedirectsToView(response, 'changelist_view')
 
     def test_get_model_solution(self):
@@ -54,6 +55,7 @@ class TestStaffViews(TestCase):
                             'solutionfile_set-TOTAL_FORMS': '3',
                             'solutionfile_set-0-file': f
                         })
+        f.close()
         self.assertNotContains(response, 'error_list')
 
     def test_task_export(self):

--- a/src/utilities/TestSuite.py
+++ b/src/utilities/TestSuite.py
@@ -116,17 +116,20 @@ def create_test_data():
     solution = Solution.objects.create(    task = task, author = user )
 
     solution_file = SolutionFile(solution = solution)
-    solution_file.file.save(
-                'GgT.java',
-                File(open(join(dirname(dirname(dirname(__file__))),
+    df = open(join(dirname(dirname(dirname(__file__))),
                 'examples',
                 'Tasks',
                 'GGT',
                 'solutions',
-                'GgT.java'))))
+                'GgT.java'))
+    solution_file.file.save(
+                'GgT.java',
+                File(df))
 
     # Attestation
     attestation = Attestation.objects.create(solution = solution, author=tutor) # final, published
+
+    df.close()
 
 def dump(obj):
     """ Kinda like obj.__meta__ but shows more, very usefull for testcase debuging. """

--- a/src/utilities/file_operations.py
+++ b/src/utilities/file_operations.py
@@ -39,8 +39,10 @@ def create_file(path, content, override=True, binary=False):
     with open(path, 'wb') as fd:
         if binary:
             fd.write(content)
+            fd.close()
         else:
             fd.write(encoding.get_utf8(encoding.get_unicode(content)))
+            fd.close()
     if (gid):
         # chown :praktomat <path>
         os.chown(path, -1, gid)
@@ -54,6 +56,7 @@ def copy_file(from_path, to_path, to_is_directory=False, override=True):
         to_path = os.path.join(to_path, os.path.basename(from_path))
     with open(from_path, "rb") as fd:
         create_file(to_path, fd.read(), override=override, binary=True)
+        fd.close()
 
 
 def create_tempfolder(path):


### PR DESCRIPTION
If you run 
`python -Wa ./Praktomat/src/manage-test.py test accounts attestation checker configuration solutions tasks
`
than python reports multiple ResourceWarnings about "unclosed files". 
I could find multiple places in Praktomat code, where `file.open()` was called without the corresponding `file.close()` 
But for some warnings I do not find the reason, so they are left inside: check them with  python -Wa ...

Signed-off-by: Robert Hartmann (@Laptop, WSL) <Robert.Hartmann@h-brs.de>