### PR TITLE
MIME type improvements

### DIFF
--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -402,9 +402,11 @@ def load_defaults(settings):
 
     d.MIMETYPE_ADDITIONAL_EXTENSIONS = \
         [("text/plain", ".properties"),
-         ("text/x-r-script", ".R"),
+         ("text/x-gradle", ".gradle"),
+         ("text/x-gradle", ".gradle.kts"),
          ("text/x-isabelle", ".thy"),
-         ("text/x-lean", ".lean"),]
+         ("text/x-lean", ".lean"),
+         ("text/x-r-script", ".R"),]
 
     # Subclassed TestSuitRunner to prepopulate unit test database.
     d.TEST_RUNNER = 'utilities.TestSuite.TestSuiteRunner'

--- a/src/solutions/forms.py
+++ b/src/solutions/forms.py
@@ -54,7 +54,7 @@ class SolutionFileForm(ModelForm):
                         (type, encoding) = mimetypes.guess_type(filename)
                         ignorred = SolutionFile.ignorred_file_names_re.search(filename)
                         supported = type and supported_types_re.match(type)
-                        is_text_file = not ignorred and type.startswith("text")
+                        is_text_file = not ignorred and type and type.startswith("text")
                         if not ignorred and not supported:
                             raise forms.ValidationError(_("The file '%(file)s' of guessed mime type '%(type)s' in this zip file is not supported." %{'file':filename, 'type':type}))
                         if is_text_file and contains_NUL_char(zip.read(filename)):


### PR DESCRIPTION
- Check if the mime type is `None` before tying to access the string. This way, the user actually gets a warning message that the detected mime type is None and thus not supported. Otherwise, we'll just get `Uhoh - something unexpected happened.`.
- Add support for detecting Gradle build files. These are often not detected by Python and the underlying mime type databases, but might be contained in submissions for Java tasks.