### PR TITLE
Introduce TEST_MAXFILENUMBER setting

### DIFF
--- a/src/checker/checker/CUnitChecker_v2.py
+++ b/src/checker/checker/CUnitChecker_v2.py
@@ -378,7 +378,7 @@ class CUnitChecker2(CheckerWithFile):
 
         cmd_par = self._test_par.split(' ') if self._test_par else []
         cmd = [os.path.join(script_dir,self.runner()),self._test_name] + cmd_par
-        [output, error, exitcode,timed_out, oom_ed] = execute_arglist(cmd, env.tmpdir(),environment_variables=environ,timeout=settings.TEST_TIMEOUT,fileseeklimit=settings.TEST_MAXFILESIZE, extradirs=[script_dir])
+        [output, error, exitcode,timed_out, oom_ed] = execute_arglist(cmd, env.tmpdir(),environment_variables=environ,timeout=settings.TEST_TIMEOUT,fileseeklimit=settings.TEST_MAXFILESIZE, filenumberlimit=settings.TEST_MAXFILENUMBER, extradirs=[script_dir])
 
         #result = self.create_result(env)
 

--- a/src/checker/checker/DejaGnu.py
+++ b/src/checker/checker/DejaGnu.py
@@ -133,6 +133,7 @@ class DejaGnuTester(Checker, DejaGnu):
                         environment_variables=environ,
                         timeout=settings.TEST_TIMEOUT,
                         fileseeklimit=settings.TEST_MAXFILESIZE,
+                        filenumberlimit=settings.TEST_MAXFILENUMBER,
                         extradirs=[env.tmpdir(), script_dir]
                         )
         output = encoding.get_unicode(output)

--- a/src/checker/checker/DiffChecker.py
+++ b/src/checker/checker/DiffChecker.py
@@ -87,6 +87,7 @@ class DiffChecker(Checker):
                             timeout=settings.TEST_TIMEOUT,
                             maxmem=settings.TEST_MAXMEM,
                             fileseeklimit=settings.TEST_MAXFILESIZE,
+                            filenumberlimit=settings.TEST_MAXFILENUMBER,
                             extradirs = [script_dir],
                             )
         output = force_unicode(output, errors='replace')

--- a/src/checker/checker/HaskellTestFrameWorkChecker.py
+++ b/src/checker/checker/HaskellTestFrameWorkChecker.py
@@ -114,7 +114,7 @@ class HaskellTestFrameWorkChecker(CheckerWithFile):
         environ['LANGUAGE'] = settings.LANGUAGE
 
         cmd = ["./"+self.module_binary_name(), "--maximum-generated-tests=1000"]
-        [output, error, exitcode, timed_out, oom_ed] = execute_arglist(cmd, env.tmpdir(), environment_variables=environ, timeout=settings.TEST_TIMEOUT, fileseeklimit=settings.TEST_MAXFILESIZE)
+        [output, error, exitcode, timed_out, oom_ed] = execute_arglist(cmd, env.tmpdir(), environment_variables=environ, timeout=settings.TEST_TIMEOUT, fileseeklimit=settings.TEST_MAXFILESIZE, filenumberlimit=settings.TEST_MAXFILENUMBER)
 
         result = self.create_result(env)
 

--- a/src/checker/checker/JUnitChecker.py
+++ b/src/checker/checker/JUnitChecker.py
@@ -84,7 +84,7 @@ class JUnitChecker(Checker):
         environ['LANGUAGE'] = settings.LANGUAGE
 
         cmd = [settings.JVM_SECURE, "-cp", settings.JAVA_LIBS[self.junit_version]+":.", self.runner(), self.class_name]
-        [output, error, exitcode, timed_out, oom_ed] = execute_arglist(cmd, env.tmpdir(), environment_variables=environ, timeout=settings.TEST_TIMEOUT, fileseeklimit=settings.TEST_MAXFILESIZE, extradirs=[script_dir])
+        [output, error, exitcode, timed_out, oom_ed] = execute_arglist(cmd, env.tmpdir(), environment_variables=environ, timeout=settings.TEST_TIMEOUT, fileseeklimit=settings.TEST_MAXFILESIZE, filenumberlimit=settings.TEST_MAXFILENUMBER, extradirs=[script_dir])
 
         result = self.create_result(env)
 

--- a/src/checker/checker/JavaChecker.py
+++ b/src/checker/checker/JavaChecker.py
@@ -57,7 +57,7 @@ class JavaChecker(Checker):
             str(env.user().last_name),
             str(env.solution().id)]
         [output, error, exitcode, timed_out, oom_ed] = execute_arglist(cmd, env.tmpdir(), environment_variables=environ,
-            timeout=settings.TEST_TIMEOUT, fileseeklimit=settings.TEST_MAXFILESIZE, extradirs=[script_dir])
+            timeout=settings.TEST_TIMEOUT, fileseeklimit=settings.TEST_MAXFILESIZE, filenumberlimit=settings.TEST_MAXFILENUMBER, extradirs=[script_dir])
 
         result = self.create_result(env)
 

--- a/src/checker/checker/ScriptChecker.py
+++ b/src/checker/checker/ScriptChecker.py
@@ -73,6 +73,7 @@ class ScriptChecker(Checker):
                             timeout=settings.TEST_TIMEOUT,
                             maxmem=settings.TEST_MAXMEM,
                             fileseeklimit=settings.TEST_MAXFILESIZE,
+                            filenumberlimit=settings.TEST_MAXFILENUMBER,
                             extradirs = [script_dir],
                             )
         output = force_text(output, errors='replace')

--- a/src/checker/compiler/CLinker.py
+++ b/src/checker/compiler/CLinker.py
@@ -49,7 +49,7 @@ class CLinker(Linker, LibraryHelper, MainNeedHelper):
                         # Next let's shell out and search in object file for main
                         script_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)),'scripts')
                         cmd = [os.path.join(script_dir, self._OBJECTINSPECTOR)] + self._OBJINSPECT_PAR + [os.path.join(dirpath,filename)]
-                        [objinfo,error,exitcode,timed_out,oom_ed]  = execute_arglist(cmd , env.tmpdir(), self.environment(), timeout=settings.TEST_TIMEOUT, fileseeklimit=settings.TEST_MAXFILESIZE, extradirs=[script_dir])
+                        [objinfo,error,exitcode,timed_out,oom_ed]  = execute_arglist(cmd , env.tmpdir(), self.environment(), timeout=settings.TEST_TIMEOUT, fileseeklimit=settings.TEST_MAXFILESIZE, filenumberlimit=settings.TEST_MAXFILENUMBER, extradirs=[script_dir])
                         if exitcode != 0 :
                             raise self.NotFoundError("Internal Server Error. Processing files %s" % ",".join(obj_files)+"\n"+objinfo)
                         tmp = re.search(nm_rx, objinfo)

--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -398,6 +398,9 @@ def load_defaults(settings):
     # JUnitChecker, ScriptChecker,
     d.TEST_MAXLOGSIZE=64
 
+    # Maximum number of open file descriptors for a checker.
+    d.TEST_MAXFILENUMBER=128
+
     d.NUMBER_OF_TASKS_TO_BE_CHECKED_IN_PARALLEL = 1
 
     d.MIMETYPE_ADDITIONAL_EXTENSIONS = \


### PR DESCRIPTION
This allows specifying the maximum number of open file descriptors for a checker.

This is useful, for example, when executing Gradle in combination with a ScriptChecker. In that case, the limit of 128 open file descriptors isn't sufficient and needs to be increased. In my opinion, moving this limit into a setting makes an adjustment a lot easier.