### PR TITLE
ScriptChecker: add environment variables for task

### DIFF
--- a/src/checker/basemodels.py
+++ b/src/checker/basemodels.py
@@ -135,6 +135,8 @@ class CheckerEnvironment:
         self._sources = []
         for file in solution.solutionfile_set.all().order_by('file'):
             self._sources.append((file.path(), file.content()))
+        # Associated task for this solution
+        self._task = solution.task
         # Submitter of this program
         self._user = solution.author
         # Executable program
@@ -174,6 +176,9 @@ class CheckerEnvironment:
         """ Add source to the list of source files. [(name, content)...] """
         self._sources.append((path, content))
 
+    def task(self):
+        """ Returns the associated task for this solution. """
+        return self._task
 
     def user(self):
         """ Returns the submitter of this program (class User). """

--- a/src/checker/checker/ScriptChecker.py
+++ b/src/checker/checker/ScriptChecker.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 
-import os, re, string
+import os, re, string, sys
 
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -52,6 +52,8 @@ class ScriptChecker(Checker):
         args = [path] + filenames
 
         environ = {}
+        environ['TASK_ID'] = str(env.task().id)
+        environ['TASK_TITLE'] = str(env.task().title).encode(sys.getfilesystemencoding(), 'ignore').decode() # The title may include invalid characters (e.g. umlauts) -> ignore them
         environ['USER'] = str(env.user().id)
         environ['USER_MATR'] = str(env.user().mat_number)
         environ['SOLUTION_ID'] = str(env.solution().id)
@@ -116,7 +118,6 @@ class WarningScriptCheckerFormSet(forms.BaseInlineFormSet):
 
             # In Universal Newline mode, python will collect encountered newlines
 
-            import sys
             PY2 = sys.version_info[0] == 2
             PY3 = sys.version_info[0] == 3
             if PY3:


### PR DESCRIPTION
This adds the environment variables `TASK_ID` and `TASK_TITLE` for the ScriptChecker. Since the task's title may contain special characters (such as umlauts), those will be simply ignored to prevent the checker from crashing when setting the environments variables.

These variables may be useful when working with external resources which are related to a specific task. The checker script could then be independent from a task, so that it can be reused (uploaded again for another task without a modification) across multiple tasks which require similar checks.