### PR TITLE
Remove praktomat_default from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,11 @@ pip install -r Praktomat/requirements.txt
 ```
 
 Now create a database. Using postgres on Ubuntu, this might work for creating
-a database "praktomat_default". Also edit `pg_hba.conf` to allow the access.
+a database "praktomat_<PRAKTOMAT_ID>". Also edit `pg_hba.conf` to allow the access.
 Your database-system should be configured to UTF-8.
 
 ```bash
 sudo -u postgres createuser -DRS praktomat
-sudo -u postgres createdb --encoding UTF8 -O praktomat praktomat_default
 sudo -u postgres createdb --encoding UTF8 -O praktomat praktomat_<PRAKTOMAT_ID>
 ```
 


### PR DESCRIPTION
From what I can see, creating a database `praktomat_default` isn't required. Everything seems to run fine without this database being created. If I missed something, let me know. Otherwise, I think this should be removed from the README.