### PR TITLE
Only show one SolutionFileForm instead of three

### DIFF
--- a/src/solutions/forms.py
+++ b/src/solutions/forms.py
@@ -78,5 +78,5 @@ class MyBaseInlineFormSet(BaseInlineFormSet):
         if not reduce(lambda x, y: x + y.changed_data, self.forms, []):
             raise forms.ValidationError(_('You must choose at least one file.'))
 
-SolutionFormSet = inlineformset_factory(Solution, SolutionFile, form=SolutionFileForm, formset=MyBaseInlineFormSet, can_delete=False, extra=3)
+SolutionFormSet = inlineformset_factory(Solution, SolutionFile, form=SolutionFileForm, formset=MyBaseInlineFormSet, can_delete=False, extra=1)
 ModelSolutionFormSet = inlineformset_factory(Solution, SolutionFile, form=SolutionFileForm, formset=MyBaseInlineFormSet, can_delete=False, extra=1)


### PR DESCRIPTION
Instead of showing three forms to select a file for a solution, only a single form will be displayed per default. You can still add more of those forms with the plus button.

I think this is a lot less confusing for students. Also, the help text mentions that the files for the solution shall be packed into a zip archive rather than being selected/uploaded individually.

Or is there a relevant use case where three forms should be shown initially to not have to manually add the additional forms?