### PR TITLE
Only mark a solution as final if the current final solution is older

### DIFF
--- a/src/solutions/views.py
+++ b/src/solutions/views.py
@@ -156,7 +156,14 @@ def solution_list(request, task_id, user_id=None):
                          send_mail(_("%s submission confirmation") % settings.SITE_NAME, t.render(c), None, [solution.author.email])
 
 
-            if solution.accepted or get_settings().accept_all_solutions:
+            current_final_solution = Solution.objects.filter(task=task, author=author, final=True).first()
+            newer_final_solution_existing = False
+            if current_final_solution is not None:
+                if current_final_solution.creation_date > solution.creation_date:
+                    # The student (re-)submitted another final solution while the checkers were running
+                    # This can't be the final solution anymore
+                    newer_final_solution_existing = True
+            if (solution.accepted or get_settings().accept_all_solutions) and not newer_final_solution_existing:
                 solution.final = True
                 solution.save()
 

--- a/src/solutions/views.py
+++ b/src/solutions/views.py
@@ -112,6 +112,17 @@ def solution_list(request, task_id, user_id=None):
             run_all_checker = bool(User.objects.filter(id=user_id, tutorial__tutors__pk=request.user.id) and task.expired() or request.user.is_trainer and task.expired() )
             solution.check_solution(run_all_checker)
 
+            current_final_solution = Solution.objects.filter(task=task, author=author, final=True).first()
+            newer_final_solution_existing = False
+            if current_final_solution is not None:
+                if current_final_solution.creation_date > solution.creation_date:
+                    # The student (re-)submitted another final solution while the checkers were running
+                    # This can't be the final solution anymore
+                    newer_final_solution_existing = True
+            if (solution.accepted or get_settings().accept_all_solutions) and not newer_final_solution_existing:
+                solution.final = True
+                solution.save()
+
             if solution.accepted:
                 # Send submission confirmation email
                 t = loader.get_template('solutions/submission_confirmation_email.html')
@@ -154,18 +165,6 @@ def solution_list(request, task_id, user_id=None):
                 else: #we are sending unsigned email
                     if solution.author.email:
                          send_mail(_("%s submission confirmation") % settings.SITE_NAME, t.render(c), None, [solution.author.email])
-
-
-            current_final_solution = Solution.objects.filter(task=task, author=author, final=True).first()
-            newer_final_solution_existing = False
-            if current_final_solution is not None:
-                if current_final_solution.creation_date > solution.creation_date:
-                    # The student (re-)submitted another final solution while the checkers were running
-                    # This can't be the final solution anymore
-                    newer_final_solution_existing = True
-            if (solution.accepted or get_settings().accept_all_solutions) and not newer_final_solution_existing:
-                solution.final = True
-                solution.save()
 
             return HttpResponseRedirect(reverse('solution_detail', args=[solution.id]))
     else:

--- a/src/templates/solutions/submission_confirmation_email.html
+++ b/src/templates/solutions/submission_confirmation_email.html
@@ -1,6 +1,6 @@
 {% load i18n %}{% autoescape off %}{% trans "Hello " %}{{solution.author}},
 
-{% if uploader %}a{% else %}your{% endif %} solution to the task "{{solution.task}}" has been successfully uploaded{% if uploader %} in your name by trainer {{uploader}}{% endif %} and is now your current final solution.
+{% if uploader %}a{% else %}your{% endif %} solution to the task "{{solution.task}}" has been successfully uploaded{% if uploader %} in your name by trainer {{uploader}}{% endif %}{% if not solution.final %}.{% else %} and is now your current final solution.{% endif %}
 
 You can view the uploaded solution here: {{protocol}}://{{ domain }}{% url "solution_detail" solution_id=solution.id %}
 


### PR DESCRIPTION
Current situation: imagine a task with a non-required checker. A student submits a working solution 1. Then, he uploads a solution 2 for which the checkers are running very long (probably running into a timeout). He then resubmits solution 1 while the checkers for solution 2 are still running. Since the checkers don't run on a resubmission, the solution will instantly be marked as final. When the checkers for solution 2 finish, solution 2 will be marked as final.

I think this behavior is wrong. If a newer solution (marked as final) than the one that just got checked exists, the final flag should not be moved.