### PR TITLE
Hide binary files on the user interface

### DIFF
--- a/src/attestation/views.py
+++ b/src/attestation/views.py
@@ -293,7 +293,7 @@ def new_attestation_for_solution(request, solution_id, force_create = False):
 
     attest = Attestation(solution = solution, author = request.user)
     attest.save()
-    for solutionFile in  solution.solutionfile_set.filter(mime_type__startswith='text'):
+    for solutionFile in solution.textSolutionFiles():
         annotatedFile = AnnotatedSolutionFile(attestation = attest, solution_file=solutionFile, content=solutionFile.content())
         annotatedFile.save()
     for rating in solution.task.rating_set.all():

--- a/src/templates/attestation/attestation_edit.html
+++ b/src/templates/attestation/attestation_edit.html
@@ -122,7 +122,7 @@
 					{% include "solutions/checker_results_inline.html" %}
 				{% endwith %}
 				<br/>
-				{% with model_solution.solutionfile_set.all as solutionfiles %}
+				{% with model_solution.textSolutionFiles as solutionfiles %}
 					{% include "solutions/solution_files_inline.html" %}
 				{% endwith %}
 		</div>
@@ -141,7 +141,7 @@
 				{% include "solutions/checker_results_inline.html" %}
 			{% endwith %}
 			<br/>
-			{% with solution.solutionfile_set.all as solutionfiles %}
+			{% with solution.textSolutionFiles as solutionfiles %}
 				{% include "solutions/solution_files_inline.html" %}
 			{% endwith %}
 		</div>

--- a/src/templates/attestation/attestation_view.html
+++ b/src/templates/attestation/attestation_view.html
@@ -111,7 +111,7 @@
 {% if user.is_trainer or user.is_tutor %}
 <h2>{% trans "Original Files" %}</h2>
 <div class="filetabs">
-{% with attest.solution.solutionfile_set.all as solutionfiles %}
+{% with attest.solution.textSolutionFiles as solutionfiles %}
         {% include "solutions/solution_files_inline.html" %}
 {% endwith %}
 </div>

--- a/src/templates/solutions/solution_detail.html
+++ b/src/templates/solutions/solution_detail.html
@@ -74,7 +74,7 @@
 {% endif %}
 
 <h2>{% trans "Files" %}</h2>
-{% with solution.solutionfile_set.all as solutionfiles %}
+{% with solution.textSolutionFiles as solutionfiles %}
 	{% include "solutions/solution_files_inline.html" %}
 {% endwith %}
 


### PR DESCRIPTION
When binary files are submitted, they are currently also shown on the user interface with the content "Binary data". These binary files don't really need to be shown on the user interface. This makes finding the file you're searching for easier. If you need to access to binary files, you can still download the (whole) solution.
The only drawbacks with this approach are that you'll lose the ability to view what binary files were submitted. Also you can't just download a single binary file through the user interface anymore.

I'd prefer to have binary files hidden on the user interface instead of having the current situation. But let me know what you think about this. Maybe my approach would break something essential for someone else.