### PR TITLE
Don't validate mat_number with DUMMY_MAT_NUMBERS

### DIFF
--- a/src/accounts/models.py
+++ b/src/accounts/models.py
@@ -24,6 +24,10 @@ from configuration import get_settings
 
 
 def validate_mat_number(value):
+    if settings.DUMMY_MAT_NUMBERS:
+        # If we're using dummy mat numbers, we don't care if they are valid
+        return True
+
     regex = get_settings().mat_number_validation_regex
     if regex:
         RegexValidator("^"+regex+"$", message="This is not a valid student number.", code="")(value)


### PR DESCRIPTION
Currently, when the setting `DUMMY_MAT_NUMBERS` is set to True, you'll still get an error message saying "This is not a valid student number.", when editing a user from the admin interface. If the value is deleted, you can save the user and the mat_number will be set to the user id. With the default validation regex, this isn't a valid mat_number (assuming there are less than 10000 users), which is why the editing fails with the dummy mat number filled in. I think a dummy mat number doesn't need to be validated. It is always valid, as it is just inserted to prevent the field from being blank. I believe nobody's going to care about the mat_number when using `DUMMY_MAT_NUMBERS`. Or are there other opinions on this?