### PR TITLE
Fix in defaults.py preventing AttributeError

### DIFF
--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -20,7 +20,11 @@ def load_defaults(settings):
 
     # import settings so that we can conveniently use the settings here
     for k, v in settings.items():
-        if not isinstance(v, collections.abc.Callable) and not k.startswith('__'):
+        try:
+            from collections.abc import Callable  # noqa
+        except ImportError:
+            from collections import Callable  # noqa
+        if not isinstance(v, Callable) and not k.startswith('__'):
             globals()[k] = v
 
     class D(object):


### PR DESCRIPTION
Depending on python versions running "./src/manage-test.py" failed with
```
src/settings/defaults.py", line 23, in load_defaults
    if not isinstance(v, collections.abc.Callable) and not k.startswith('__'):
AttributeError: 'module' object has no attribute 'abc'
```
i.e. Travis run from 7th May 2022 failed : https://app.travis-ci.com/github/ifrh/Praktomat/jobs/569431166


This fix works: see https://app.travis-ci.com/github/ifrh/Praktomat/builds/250348409