### PR TITLE
safeexec: replace preexec_fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Prerequisites: 3rd-Party libraries and programms
   Praktomat requires some 3rd-Party libraries programs to run.
   On a Ubuntu/Debian System, these can be installed by installing the following packages:
 
+    util-linux
     libpq-dev
     zlib1g-dev
     libmysqlclient-dev (or: default-libmysqlclient-dev)


### PR DESCRIPTION
Since Python 3.8, the `preexec_fn` parameter (subprocess.Popen) is not supported within subinterpreters anymore. If possible, you're also advised to not use this paramater at all.

This pull request should fix #312.
Instead of using a preexec function, this patch makes use of the `start_new_session` parameter to set the session id. The `prlimit` tool is now used to limit the resources (number of open file descriptors and maximum file size).

I think this is as close as we can get to the solution we had previously. The only downside of this solution is that we rely on `prlimit` which is only available on Linux. But I think at this point, the Praktomat is supposed to run on Linux only anyway, right?

If you have any concerns about this approach, let me know :)