### PR TITLE
Bugfix not null constraint mime type missing

### DIFF
--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -313,9 +313,10 @@ class TestChecker(TestCase):
         # TODO: This is duplicated from solutions/forms.py. Where should this go?
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)
-        print(mimetypes.types_map['.R'])
+        #print(mimetypes.types_map['.R'])
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
+        self.assertEqual(str(mimetypes.types_map['.R']),solution_file.mime_type, "Mimetype for extension R should be guessed right")
         self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
             solution_file.file.save('example.R', File(fd))

--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -307,8 +307,13 @@ class TestChecker(TestCase):
             self.assertTrue(checkerresult.passed, checkerresult.log)
 
     def test_r_checker(self):
+        import mimetypes
+        # TODO: This is duplicated from solutions/forms.py. Where should this go?
+        for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
+            mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
+            solution_file.mime_type=mimetypes.guess_type('example.R')[0]
             solution_file.file.save('example.R', File(fd))
 
         RChecker.RChecker.objects.create(
@@ -328,8 +333,13 @@ class TestChecker(TestCase):
             solution_file.delete()
 
     def test_r_checker_2(self):
+        import mimetypes
+        # TODO: This is duplicated from solutions/forms.py. Where should this go?
+        for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
+            mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
+            solution_file.mime_type=mimetypes.guess_type('example.R')[0]
             solution_file.file.save('example.R', File(fd))
 
         RChecker.RChecker.objects.create(
@@ -350,8 +360,13 @@ class TestChecker(TestCase):
                 solution_file.delete()
 
     def test_r_checker_3(self):
+        import mimetypes
+        # TODO: This is duplicated from solutions/forms.py. Where should this go?
+        for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
+            mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
+            solution_file.mime_type=mimetypes.guess_type('example.R')[0]
             solution_file.file.save('example.R', File(fd))
 
         RChecker.RChecker.objects.create(
@@ -370,11 +385,17 @@ class TestChecker(TestCase):
             solution_file.delete()
 
     def test_r_checker_4(self):
+        import mimetypes
+        # TODO: This is duplicated from solutions/forms.py. Where should this go?
+        for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
+            mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
+            solution_file.mime_type=mimetypes.guess_type('example.R')[0]
             solution_file.file.save('example.R', File(fd))
         solution_file2 = SolutionFile(solution = self.solution)
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
+            solution_file2.mime_type=mimetypes.guess_type('example.R')[0]
             solution_file2.file.save('example2.R', File(fd))
 
         RChecker.RChecker.objects.create(

--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -401,7 +401,7 @@ class TestChecker(TestCase):
 
         solution_file2 = SolutionFile(solution = self.solution)
         solution_file2.mime_type=mimetypes.guess_type('example2.R')[0]
-        with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example2.R',)) as fd:
+        with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
             solution_file2.file.save('example2.R', File(fd))
 
         RChecker.RChecker.objects.create(

--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -313,7 +313,7 @@ class TestChecker(TestCase):
         # TODO: This is duplicated from solutions/forms.py. Where should this go?
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)
-        print(mimetypes.knownfiles)
+        print(mimetypes.types_map['.R'])
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
         self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")

--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -312,8 +312,8 @@ class TestChecker(TestCase):
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
+        solution_file.mime_type=mimetypes.guess_type('example.R')[0]
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
-            solution_file.mime_type=mimetypes.guess_type('example.R')[0]
             solution_file.file.save('example.R', File(fd))
 
         RChecker.RChecker.objects.create(
@@ -338,8 +338,8 @@ class TestChecker(TestCase):
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
+        solution_file.mime_type=mimetypes.guess_type('example.R')[0]
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
-            solution_file.mime_type=mimetypes.guess_type('example.R')[0]
             solution_file.file.save('example.R', File(fd))
 
         RChecker.RChecker.objects.create(
@@ -365,8 +365,8 @@ class TestChecker(TestCase):
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
+        solution_file.mime_type=mimetypes.guess_type('example.R')[0]
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
-            solution_file.mime_type=mimetypes.guess_type('example.R')[0]
             solution_file.file.save('example.R', File(fd))
 
         RChecker.RChecker.objects.create(
@@ -390,12 +390,13 @@ class TestChecker(TestCase):
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
+        solution_file.mime_type=mimetypes.guess_type('example.R')[0]
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
-            solution_file.mime_type=mimetypes.guess_type('example.R')[0]
             solution_file.file.save('example.R', File(fd))
+
         solution_file2 = SolutionFile(solution = self.solution)
+        solution_file2.mime_type=mimetypes.guess_type('example.R')[0]
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
-            solution_file2.mime_type=mimetypes.guess_type('example.R')[0]
             solution_file2.file.save('example2.R', File(fd))
 
         RChecker.RChecker.objects.create(

--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -313,6 +313,8 @@ class TestChecker(TestCase):
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
+        self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
+        print(solution_file.mime_type)
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
             solution_file.file.save('example.R', File(fd))
 
@@ -339,6 +341,7 @@ class TestChecker(TestCase):
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
+        self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
             solution_file.file.save('example.R', File(fd))
 
@@ -366,6 +369,7 @@ class TestChecker(TestCase):
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
+        self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
             solution_file.file.save('example.R', File(fd))
 
@@ -391,12 +395,13 @@ class TestChecker(TestCase):
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
+        self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
             solution_file.file.save('example.R', File(fd))
 
         solution_file2 = SolutionFile(solution = self.solution)
-        solution_file2.mime_type=mimetypes.guess_type('example.R')[0]
-        with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
+        solution_file2.mime_type=mimetypes.guess_type('example2.R')[0]
+        with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example2.R',)) as fd:
             solution_file2.file.save('example2.R', File(fd))
 
         RChecker.RChecker.objects.create(

--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -308,13 +308,14 @@ class TestChecker(TestCase):
 
     def test_r_checker(self):
         import mimetypes
+        mimetypes.init()
+        self.assertTrue(mimetypes.inited)
         # TODO: This is duplicated from solutions/forms.py. Where should this go?
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
         self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
-        print(solution_file.mime_type)
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
             solution_file.file.save('example.R', File(fd))
 
@@ -336,6 +337,7 @@ class TestChecker(TestCase):
 
     def test_r_checker_2(self):
         import mimetypes
+        mimetypes.init()
         # TODO: This is duplicated from solutions/forms.py. Where should this go?
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)
@@ -364,6 +366,7 @@ class TestChecker(TestCase):
 
     def test_r_checker_3(self):
         import mimetypes
+        mimetypes.init()
         # TODO: This is duplicated from solutions/forms.py. Where should this go?
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)
@@ -390,6 +393,7 @@ class TestChecker(TestCase):
 
     def test_r_checker_4(self):
         import mimetypes
+        mimetypes.init()
         # TODO: This is duplicated from solutions/forms.py. Where should this go?
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)

--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -313,9 +313,12 @@ class TestChecker(TestCase):
         # TODO: This is duplicated from solutions/forms.py. Where should this go?
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)
-        #print(mimetypes.types_map['.R'])
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
+        #ToDo: Work in progress: Bughunting for Python 3.9.12 ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # Unit Tests for R Checker fail : missing mimetype for example.R
+        # django.db.utils.IntegrityError: NOT NULL constraint failed: solutions_solutionfile.mime_type
+        print("mimetypes.types_map['.R'] = %s , mimetypes.guess_type('example.R')[0] = %s" % (mimetypes.types_map['.R'],solution_file.mime_type))
         self.assertEqual(str(mimetypes.types_map['.R']),solution_file.mime_type, "Mimetype for extension R should be guessed right")
         self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
@@ -345,6 +348,9 @@ class TestChecker(TestCase):
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
+        #ToDo: Work in progress: Bughunting for Python 3.9.12 ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # Unit Tests for R Checker fail : missing mimetype for example.R
+        # django.db.utils.IntegrityError: NOT NULL constraint failed: solutions_solutionfile.mime_type
         self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
             solution_file.file.save('example.R', File(fd))
@@ -374,6 +380,9 @@ class TestChecker(TestCase):
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
+        #ToDo: Work in progress: Bughunting for Python 3.9.12 ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # Unit Tests for R Checker fail : missing mimetype for example.R
+        # django.db.utils.IntegrityError: NOT NULL constraint failed: solutions_solutionfile.mime_type
         self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
             solution_file.file.save('example.R', File(fd))
@@ -401,7 +410,11 @@ class TestChecker(TestCase):
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
-        self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
+        #ToDo: Work in progress: Bughunting for Python 3.9.12 ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # Unit Tests for R Checker fail : missing mimetype for example.R
+        # django.db.utils.IntegrityError: NOT NULL constraint failed: solutions_solutionfile.mime_type
+        # at one place let show the uncatched problem
+        # self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
             solution_file.file.save('example.R', File(fd))
 

--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -313,6 +313,7 @@ class TestChecker(TestCase):
         # TODO: This is duplicated from solutions/forms.py. Where should this go?
         for (mimetype, extension) in settings.MIMETYPE_ADDITIONAL_EXTENSIONS:
             mimetypes.add_type(mimetype, extension, strict=True)
+        print(mimetypes.knownfiles)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
         self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")

--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -315,10 +315,12 @@ class TestChecker(TestCase):
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
-        #ToDo: Work in progress: Bughunting for Python 3.9.12 ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # Bughunting for Python 3.9.12 and above
+        # at time of bughunting ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # see https://github.com/KITPraktomatTeam/Praktomat/issues/336
+        #
         # Unit Tests for R Checker fail : missing mimetype for example.R
         # django.db.utils.IntegrityError: NOT NULL constraint failed: solutions_solutionfile.mime_type
-        print("mimetypes.types_map['.R'] = %s , mimetypes.guess_type('example.R')[0] = %s" % (mimetypes.types_map['.R'],solution_file.mime_type))
         self.assertEqual(str(mimetypes.types_map['.R']),solution_file.mime_type, "Mimetype for extension R should be guessed right")
         self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:
@@ -348,7 +350,10 @@ class TestChecker(TestCase):
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
-        #ToDo: Work in progress: Bughunting for Python 3.9.12 ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # Bughunting for Python 3.9.12 and above
+        # at time of bughunting ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # see https://github.com/KITPraktomatTeam/Praktomat/issues/336
+        #
         # Unit Tests for R Checker fail : missing mimetype for example.R
         # django.db.utils.IntegrityError: NOT NULL constraint failed: solutions_solutionfile.mime_type
         self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
@@ -380,7 +385,10 @@ class TestChecker(TestCase):
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
-        #ToDo: Work in progress: Bughunting for Python 3.9.12 ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # Bughunting for Python 3.9.12 and above
+        # at time of bughunting ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # see https://github.com/KITPraktomatTeam/Praktomat/issues/336
+        #
         # Unit Tests for R Checker fail : missing mimetype for example.R
         # django.db.utils.IntegrityError: NOT NULL constraint failed: solutions_solutionfile.mime_type
         self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
@@ -410,9 +418,13 @@ class TestChecker(TestCase):
             mimetypes.add_type(mimetype, extension, strict=True)
         solution_file = SolutionFile(solution = self.solution)
         solution_file.mime_type=mimetypes.guess_type('example.R')[0]
-        #ToDo: Work in progress: Bughunting for Python 3.9.12 ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # Bughunting for Python 3.9.12 and above
+        # at time of bughunting ... uses pysqlite 2.6.0 with SQLite 3.38.3
+        # see https://github.com/KITPraktomatTeam/Praktomat/issues/336
+        #
         # Unit Tests for R Checker fail : missing mimetype for example.R
         # django.db.utils.IntegrityError: NOT NULL constraint failed: solutions_solutionfile.mime_type
+        #
         # at one place let show the uncatched problem
         # self.assertIsNotNone(solution_file.mime_type, "Mimetype for example.R shouldn't be None")
         with open(join(dirname(dirname(dirname(__file__))), 'examples', 'example.R',)) as fd:

--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -20,7 +20,11 @@ def load_defaults(settings):
 
     # import settings so that we can conveniently use the settings here
     for k, v in settings.items():
-        if not isinstance(v, collections.abc.Callable) and not k.startswith('__'):
+        try:
+            from collections.abc import Callable  # noqa
+        except ImportError:
+            from collections import Callable  # noqa
+        if not isinstance(v, Callable) and not k.startswith('__'):
             globals()[k] = v
 
     class D(object):

--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -410,8 +410,9 @@ def load_defaults(settings):
          ("text/x-gradle", ".gradle.kts"),
          ("text/x-isabelle", ".thy"),
          ("text/x-lean", ".lean"),
-         ("text/x-r-script", ".R"), 
-	 ("text/x-r-script", ".r"),]
+         ("text/x-r-script", ".R"),
+         ("text/x-r-script", ".r"),# Fixes KITPraktomatTeam/Praktomat#336 as workaround for issue in Python 3.9.12 and above: Add filename extension with small letter r to dict of additional mimetypes , more information see issue Python stdlib  92455
+         ]
 
     # Subclassed TestSuitRunner to prepopulate unit test database.
     d.TEST_RUNNER = 'utilities.TestSuite.TestSuiteRunner'

--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -410,7 +410,8 @@ def load_defaults(settings):
          ("text/x-gradle", ".gradle.kts"),
          ("text/x-isabelle", ".thy"),
          ("text/x-lean", ".lean"),
-         ("text/x-r-script", ".R"),]
+         ("text/x-r-script", ".R"), 
+	 ("text/x-r-script", ".r"),]
 
     # Subclassed TestSuitRunner to prepopulate unit test database.
     d.TEST_RUNNER = 'utilities.TestSuite.TestSuiteRunner'


### PR DESCRIPTION
This pull request should fix https://github.com/KITPraktomatTeam/Praktomat/issues/336
using a workaround needed caused by Python stdlib bug https://github.com/python/cpython/issues/92455.

I changed in  `src/checker/tests.py` all Unit Tests for R Checker which fail by *NOT NULL constraint : missing mimetype for example.R*
And I add a mimetype for ("text/x-r-script", ".r") in `src/settings/defaults.py`.

Rationale:
since merged pull requests in Python stdlib `mimetypes.guess_type` only searches for small letters to determine mimetype for files.

* \[python:main\] https://github.com/python/cpython/pull/30229
* \[python:3.9\] https://github.com/python/cpython/pull/31903
* \[python:3.10\] https://github.com/python/cpython/pull/31904

Because the file `example.R` has capital letter, a mimetype  for that endig has been added using the *capital letter* `R`.
https://github.com/KITPraktomatTeam/Praktomat/blob/d7707f6b4f5d9b5c1eab61d8ea80313bf0486ff4/src/settings/defaults.py#L403-L410
Sadly the current implementation of `mimetypes.guess_type` in Python stdlib can only handle *small letters*.