### PR TITLE
set CBuilder, CppBuilder to "required" , Optimise failure message in test_CUnitCppUnit_Checker.py

### DIFF
--- a/src/checker/compiler/CBuilder.py
+++ b/src/checker/compiler/CBuilder.py
@@ -43,6 +43,7 @@ class CheckerForm(AlwaysChangedModelForm):
         self.fields["_output_flags"].initial = "-c"
         #self.fields["_libs"].initial = ""
         self.fields["_file_pattern"].initial = r"^[a-zA-Z0-9_]*\.[cC]$"
+        self.fields["required"].initial = True
 
 class CBuilderInline(CheckerInline):
     model = CBuilder

--- a/src/checker/compiler/CXXBuilder.py
+++ b/src/checker/compiler/CXXBuilder.py
@@ -45,6 +45,7 @@ class CheckerForm(AlwaysChangedModelForm):
         #self.fields["_libs"].initial = ""
         # GCC accepts the following extensions for C++ files: ".cc", ".cxx", ".cpp", ".c++", ".C".
         self.fields["_file_pattern"].initial = r"^[a-zA-Z0-9_]*\.(c|C|cc|CC|cxx|CXX|c\+\+|C\+\+|cpp|CPP)$"
+        self.fields["required"].initial = True
 
 class CXXBuilderInline(CheckerInline):
     model = CXXBuilder

--- a/src/hbrs_tests/test_CUnitCppUnit_Checker.py
+++ b/src/hbrs_tests/test_CUnitCppUnit_Checker.py
@@ -107,11 +107,15 @@ class ModelCUnitCppUnitCheckerTests(TestCase):
             self.assertTemplateUsed(response,'solutions/solution_detail.html')
             self.assertNotIn("Upload solution denied for now".encode("utf-8"),response.content)
             #there should be no CUNIT missing error in response
-            self.assertNotIn("cannot find -lcunit".encode("utf-8"),response.content)
-            self.assertNotIn("fatal error: CUnit/Basic.h".encode("utf-8"),response.content)
+            if "cannot find -lcunit".encode("utf-8") in response.content:
+                self.fail("could not find Cunit installation. Fix your system installation.")
+            if "fatal error: CUnit/Basic.h".encode("utf-8") in response.content:
+                self.fail("could not find Cunit installation. Fix your system installation.")
             #there should be no CPPUNIT missing error in response
-            self.assertNotIn("cannot find -lcppunit".encode("utf-8"),response.content)
-            self.assertNotIn("fatal error: cppunit/TestFixture.h".encode("utf-8"),response.content)
+            if "cannot find -lcppunit".encode("utf-8") in response.content:
+                self.fail("could not find CPPunit installation. Fix your system installation.")
+            if "fatal error: cppunit/TestFixture.h".encode("utf-8") in response.content:
+                self.fail("could not find CPPunit installation. Fix your system installation.")
             self.assertIn("This is your current final solution".encode("utf-8"),response.content)
         return openedfile;
 


### PR DESCRIPTION
Changed CBuilder and CppBuilder to "required" ( fixes https://github.com/KITPraktomatTeam/Praktomat/issues/240 )

Optimised failure message inside test_CUnitCppUnit_Checker.py