### PR TITLE
Add runallcheckers command

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,18 @@ detection program [jPlag](https://jplag.ipd.kit.edu/). Do enable this support, y
  * Copy the resulting `.jar` file somewhere on the Praktomat server.
  * In the settings, set `JPLAGJAR = /full/path/to/jplag.jar`
 
+Automating the execution of checkers
+=================
+
+To automatically run all checkers for expired tasks where not all checkers are finished yet,
+there is a command called `runallcheckers`:
+```bash
+./Praktomat/src/manage-local.py runallcheckers
+```
+
+Use Cron (or something similar) to automate the execution of this command.
+Tutors can then automatically start attesting solutions without the need of
+an admin or trainer to manually run all checkers after a task expired.
 
 PhpBB integration
 =================

--- a/src/checker/management/commands/runallcheckers.py
+++ b/src/checker/management/commands/runallcheckers.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+from tasks.models import Task
+
+class Command(BaseCommand):
+    help = 'Run all checkers for expired tasks where not all checkers are finished.'
+
+    def handle(self, *args, **options):
+        for task in Task.objects.filter(all_checker_finished = False):
+            if not task.expired():
+                continue
+
+            self.stdout.write('Running all checkers for "%s"\n' % task.title)
+            task.check_all_final_solutions()
+            task.check_all_latest_only_failed_solutions()
+        self.stdout.write('Done')

--- a/src/tasks/admin.py
+++ b/src/tasks/admin.py
@@ -88,25 +88,10 @@ class TaskAdmin(admin.ModelAdmin):
 
     def run_all_checkers_on_latest_only_failed(self,request, queryset):
         """ Rerun all checker on latest of only failed solutions including "not always" action """
-        from checker.basemodels import check_solution
-        from accounts.models import User
         start = timer()
         count = 0
         for task in queryset:
-            solution_queryset = task.solution_set
-            final_solutions_queryset = solution_queryset.filter(final=True)
-            finalusers = list(set(final_solutions_queryset.values('author').values_list('author', flat=True)))
-            only_failed_solution_set = solution_queryset.exclude(author__in=finalusers)
-
-            nonfinalusers = list( set(User.objects.all().values('id').values_list('id',flat=True)) - set(finalusers))
-
-            for user in User.objects.filter(id__in=nonfinalusers) :
-                users_only_failed_solution = only_failed_solution_set.filter(author=user).order_by('author','number')
-                ucount = int(users_only_failed_solution.count())
-                if ucount :
-                    latest_only_failed_solution=users_only_failed_solution.latest('number')
-                    check_solution(latest_only_failed_solution,True)
-                    count += 1
+            count += task.check_all_latest_only_failed_solutions()
         end = timer()
         self.message_user(request, "%d users with only failed solutions were checked (%d seconds elapsed)." % (count, end-start))
     run_all_checkers_on_latest_only_failed.short_description = "recheck only latest failed (Admin)"


### PR DESCRIPTION
This adds a command called `runallcheckers` that is accessible through "manage-local.py". The functionality is the same as the "Run all checkers" command in the admin interface. It runs on all expired tasks where the "All checkers finished" flag is not set yet.

The reasoning behind this command is that it can be automatically executed through Cron. This allows tutors to start attesting solutions without the need of an admin or trainer to manually run all checkers after a task expired. Therefore, this probably closes #306. Instead of just setting the "All checker finished" flag, this is a solution that works for all use cases.

I first tried to implement the automation using Python only. However, this is getting tricky as soon as you're using for example Apache and the WSGI for running Praktomat. Then, no python process is constantly running and the automated event couldn't get triggered. Relying on Cron instead seems like a better solution to me.