### PR TITLE
Improvements for safe-docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ submissions from the system:
 
 We recommend `USESAFEDOCKER`, as that is what we test in practice.
 
+When using `safe-docker` while Praktomat itself is already running inside a Docker container, you need to have a BusyBox image available. It is required for some temporary containers.
+
 The Praktomat tries to limit the resources available to the student submissions:
 
  * The runtime of the submission can be limited (setting `TEST_TIMEOUT`)

--- a/README.md
+++ b/README.md
@@ -347,8 +347,7 @@ The Praktomat tries to limit the resources available to the student submissions:
  * The maximum amount of memory used can be limited (setting `TEST_MAXMEM`,
    only supported with `USESAFEDOCKER`).
  * The maximum size of a file produced by a user submission (setting
-   `TEST_MAXFILESIZE`, currently not supported with `USESAFEDOCKER`, until
-   http://stackoverflow.com/questions/25789425 is resolved)
+   `TEST_MAXFILESIZE`)
 
 At the time of writing, the amount of diskspace available to the user is
 unlimited, which can probably be exploited easily.

--- a/README.md
+++ b/README.md
@@ -327,14 +327,15 @@ submissions from the system:
    `tester` which is also a member of the default group of the user that runs
    the praktomat (usually `praktomat`).
  * With `USESAFEDOCKER = True`, external commands are prefixed with
-   `safe-docker`, which you need to have installed. You can fetch it from
-   http://github.com/nomeata/safe-docker
+   `safe-docker`, which you need to have installed. You can find it in the `scripts` directory of this repository.
 
    For this to work you need to have a docker image named `safe-docker`
    installed, which needs to have all required dependencies installed. A
    suggested docker image is available in `docker-image`, so to get started simply run
 
         sudo docker build -t safe-docker docker-image
+
+   If your image is named differently, set the image name through the setting `DOCKER_IMAGE_NAME`.
 
 We recommend `USESAFEDOCKER`, as that is what we test in practice.
 

--- a/scripts/safe-docker
+++ b/scripts/safe-docker
@@ -16,6 +16,7 @@ my $ulimits = ();
 my $writable = "";
 my $no_uid_mod = "";
 my $external_dir = "";
+my $host_net = "";
 
 GetOptions (
 	"image=s" => \$image,
@@ -26,6 +27,7 @@ GetOptions (
 	"writable" => \$writable,
 	"no-uid-mod" => \$no_uid_mod,
 	"external=s" => \$external_dir,
+	"host-net" => \$host_net,
 )
 or die("Error in command line arguments\n");
 
@@ -76,7 +78,12 @@ sub add_dir {
 	}
 }
 
-push @cmd, qw!docker run --rm --sig-proxy --tmpfs /tmp --tmpfs /run --tmpfs /home --net=none!;
+push @cmd, qw!docker run --rm --sig-proxy --tmpfs /tmp --tmpfs /run --tmpfs /home!;
+if ($host_net eq "1") {
+	push @cmd, "--net=host";
+} else {
+	push @cmd, "--net=none";
+}
 if ($writable ne "1") {
 	push @cmd, "--read-only";
 }

--- a/scripts/safe-docker
+++ b/scripts/safe-docker
@@ -15,6 +15,7 @@ my $maxmemory = "1G";
 my $ulimits = ();
 my $writable = "";
 my $no_uid_mod = "";
+my $external_dir = "";
 
 GetOptions (
 	"image=s" => \$image,
@@ -24,6 +25,7 @@ GetOptions (
 	'ulimit=s' => \@ulimits,
 	"writable" => \$writable,
 	"no-uid-mod" => \$no_uid_mod,
+	"external=s" => \$external_dir,
 )
 or die("Error in command line arguments\n");
 
@@ -84,6 +86,9 @@ if ($no_uid_mod ne "1") {
 	push @cmd, (sprintf "--user=%d:%d", $uid, $gid);
 }
 add_dir($_, ":ro") for @dirs;
+if ($external_dir ne "") {
+	push @cmd, "--volume=${external_dir}:/external:ro";
+}
 add_dir($cwd, "");
 push @cmd, (sprintf "--workdir=%s", $cwd);
 push @cmd, "--name", $containername;

--- a/scripts/safe-docker
+++ b/scripts/safe-docker
@@ -22,7 +22,7 @@ GetOptions (
 	"timeout=i" => \$timeout,
 	"memory=s" => \$maxmemory,
 	'ulimit=s' => \@ulimits,
-	"writeable" => \$writable,
+	"writable" => \$writable,
 	"no-uid-mod" => \$no_uid_mod,
 )
 or die("Error in command line arguments\n");

--- a/scripts/safe-docker
+++ b/scripts/safe-docker
@@ -1,0 +1,134 @@
+#!/usr/bin/perl
+#
+# © 2014 Joachim Breitner <breitner@kit.edu>
+# Licensed under the The MIT License (MIT)
+
+use Getopt::Long;
+use IPC::Run qw/ start run timeout /;
+use Cwd;
+use Data::GUID;
+
+my $image = 'safe-docker';
+my @dirs = ();
+my $timeout = 60;
+my $maxmemory = "1G";
+my $ulimits = ();
+my $writable = "";
+my $no_uid_mod = "";
+
+GetOptions (
+	"image=s" => \$image,
+	"dir=s" => \@dirs,
+	"timeout=i" => \$timeout,
+	"memory=s" => \$maxmemory,
+	'ulimit=s' => \@ulimits,
+	"writeable" => \$writable,
+	"no-uid-mod" => \$no_uid_mod,
+)
+or die("Error in command line arguments\n");
+
+# Now @ARGV is the command to run
+die "Missing command\n" unless @ARGV;
+
+die "Missing option --image \n" unless $image;
+
+die "Needs to be run under sudo\n" unless ($< == 0 and exists $ENV{SUDO_UID});
+
+my $uid = $ENV{SUDO_UID};
+die "Cannot run as user root" unless $uid > 0;
+my $gid = $ENV{SUDO_GID};
+die "Cannot run as group root" unless $gid > 0;
+
+my $containername = sprintf "secure-tmp-%s", Data::GUID->new->as_string;
+
+my $cwd = getcwd;
+
+die "CWD contains a :" if $cwd =~ /:/;
+for (@dirs) {
+	die "--dir $_ contains a :" if $_ =~ /:/;
+}
+
+
+my @cmd;
+my @volumes;
+
+sub add_dir {
+	my ($dir, $ro) = @_;
+	if (-f "/.dockerenv") {
+		$dir =~ s!/*$!/!; # Add trailing slash if not existing
+		my $volumename = sprintf "tmp-%s", Data::GUID->new->as_string;
+		run ["docker", "volume", "create", $volumename], \undef, '>/dev/null';
+		my $helpername = "tmp-helper-${volumename}";
+		run ["docker", "run", "-d", "--volume=${volumename}:${dir}", "--name", $helpername, "busybox", "sleep", "infinity"], \undef, '>/dev/null';
+		run ["docker", "cp", "${dir}.", "${helpername}:${dir}"], \undef, '>/dev/null';
+		run ["docker", "exec", $helpername, "chown", "-R", "${uid}:${gid}", $dir], \undef, '>/dev/null';
+		run ["docker", "kill", $helpername], \undef, '>/dev/null';
+		push @cmd, "--volume=${volumename}:${dir}${ro}";
+		push @volumes, {
+			"container" => $helpername,
+			"dir" => $dir,
+			"volume" => $volumename
+		};
+	} else {
+		push @cmd, "--volume=${dir}:${dir}${ro}";
+	}
+}
+
+push @cmd, qw!docker run --rm --sig-proxy --tmpfs /tmp --tmpfs /run --tmpfs /home --net=none!;
+if ($writable ne "1") {
+	push @cmd, "--read-only";
+}
+push @cmd, (sprintf "--memory=%s", $maxmemory);
+push @cmd, (sprintf "--ulimit=%s", $_) for @ulimits;
+if ($no_uid_mod ne "1") {
+	push @cmd, (sprintf "--user=%d:%d", $uid, $gid);
+}
+add_dir($_, ":ro") for @dirs;
+add_dir($cwd, "");
+push @cmd, (sprintf "--workdir=%s", $cwd);
+push @cmd, "--name", $containername;
+push @cmd, $image;
+push @cmd, @ARGV;
+
+sub clean_and_exit {
+	my $exit_code = shift;
+
+	for my $volume_entry (@volumes) {
+		my $helpername = %$volume_entry{"container"};
+		my $dir = %$volume_entry{"dir"};
+		my $volumename = %$volume_entry{"volume"};
+		run ["docker", "cp", "${helpername}:${dir}.", $dir], \undef, '>/dev/null';
+		run ["docker", "container", "rm", $helpername], \undef, '>/dev/null';
+		run ["docker", "volume", "rm", $volumename], \undef, '>/dev/null';
+	}
+
+	exit $exit_code;
+}
+
+sub kill_docker {
+	run ["docker", "kill", $containername], \undef, '>/dev/null';
+	# magic value
+	clean_and_exit(23);
+}
+use sigtrap qw/handler kill_docker normal-signals/;
+
+
+# print @cmd;
+my $h = start \@cmd, timeout ($timeout);
+
+
+eval {
+	my $ret = $h->finish;
+};
+if ($@) {
+	my $x = $@;
+	kill_docker;
+}
+
+# This is the observed behaviour for out-of-memory, so lets report that as a
+# special value
+if ($h->result == 255 or $h->result == 137) {
+	clean_and_exit(24);
+}
+
+clean_and_exit($h->result);

--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -328,6 +328,10 @@ def load_defaults(settings):
     # If this is set to none, no additional directory will get mounted.
     d.DOCKER_CONTAINER_EXTERNAL_DIR = None
 
+    # If the Docker container should be able to access the host's network
+    # When this is set to false, the container does not have any access to the network.
+    d.DOCKER_CONTAINER_HOST_NET = False
+
 
     # be sure that you change file permission
     # sudo chown praktomat:tester praktomat/src/checker/scripts/java

--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -324,6 +324,10 @@ def load_defaults(settings):
     # When this is set to false, checkers may run as root (depending on the image).
     d.DOCKER_UID_MOD = True
 
+    # The path which to additionally mount into the checker container
+    # If this is set to none, no additional directory will get mounted.
+    d.DOCKER_CONTAINER_EXTERNAL_DIR = None
+
 
     # be sure that you change file permission
     # sudo chown praktomat:tester praktomat/src/checker/scripts/java

--- a/src/settings/defaults.py
+++ b/src/settings/defaults.py
@@ -310,6 +310,20 @@ def load_defaults(settings):
 
     d.USESAFEDOCKER = False
 
+    # The path where the safe-docker script is located
+    # By default, it is assumed to be accessible through your PATH.
+    d.SAFE_DOCKER_PATH = "safe-docker"
+
+    # The name of the Docker image to use for executing checkers
+    d.DOCKER_IMAGE_NAME = "safe-docker"
+
+    # If the file system of the Docker container should be writable or read-only
+    d.DOCKER_CONTAINER_WRITABLE = False
+
+    # If the UID and GID of the user in a Docker container should be set to the one running Praktomat
+    # When this is set to false, checkers may run as root (depending on the image).
+    d.DOCKER_UID_MOD = True
+
 
     # be sure that you change file permission
     # sudo chown praktomat:tester praktomat/src/checker/scripts/java

--- a/src/utilities/safeexec.py
+++ b/src/utilities/safeexec.py
@@ -90,6 +90,9 @@ def execute_arglist(args, working_directory, environment_variables={}, timeout=N
             command += ["--ulimit", "fsize=%d" % fileseeklimitbytes]
         for d in extradirs:
             command += ["--dir", d]
+        # Add specified external directory
+        if settings.DOCKER_CONTAINER_EXTERNAL_DIR is not None:
+            command += ["--external", settings.DOCKER_CONTAINER_EXTERNAL_DIR]
         command += ["--"]
         # add environment
         command += ["env"]

--- a/src/utilities/safeexec.py
+++ b/src/utilities/safeexec.py
@@ -84,6 +84,9 @@ def execute_arglist(args, working_directory, environment_variables={}, timeout=N
             command += ["--writable"]
         if not settings.DOCKER_UID_MOD:
             command += ["--no-uid-mod"]
+        if settings.DOCKER_CONTAINER_HOST_NET:
+            # Allow accessing the host network
+            command += ["--host-net"]
         # ensure ulimit
         command += ["--ulimit", "nofile=%d" % filenumberlimit]
         if fileseeklimit:

--- a/src/utilities/safeexec.py
+++ b/src/utilities/safeexec.py
@@ -79,13 +79,13 @@ def execute_arglist(args, working_directory, environment_variables={}, timeout=N
             timeout += 5
         if maxmem is not None:
             command += ["--memory", "%sm" % maxmem]
+        # ensure ulimit
+        command += ["--ulimit", "nofile=%d" % filenumberlimit]
+        if fileseeklimit:
+            command += ["--ulimit", "fsize=%d" % fileseeklimitbytes]
         for d in extradirs:
             command += ["--dir", d]
         command += ["--"]
-        # ensure ulimit
-        if fileseeklimit:
-            # Doesn’t work yet: http://stackoverflow.com/questions/25789425
-            command += ["bash", "-c", 'ulimit -f %d; exec \"$@\"' % fileseeklimit, "ulimit-helper"]
         # add environment
         command += ["env"]
         for k, v in environment_variables.items():

--- a/src/utilities/safeexec.py
+++ b/src/utilities/safeexec.py
@@ -70,7 +70,8 @@ def execute_arglist(args, working_directory, environment_variables={}, timeout=N
         #fixed: 22.11.2016, Robert Hartmann , H-BRS
         command += deepcopy(sudo_prefix)
     elif settings.USESAFEDOCKER:
-        command += ["sudo", "safe-docker"]
+        command += ["sudo", settings.SAFE_DOCKER_PATH]
+        command += ["--image", settings.DOCKER_IMAGE_NAME]
         # for safe-docker, we cannot kill it ourselves, due to sudo, so
         # rely on the timeout provided by safe-docker
         if timeout is not None:
@@ -79,6 +80,10 @@ def execute_arglist(args, working_directory, environment_variables={}, timeout=N
             timeout += 5
         if maxmem is not None:
             command += ["--memory", "%sm" % maxmem]
+        if settings.DOCKER_CONTAINER_WRITABLE:
+            command += ["--writable"]
+        if not settings.DOCKER_UID_MOD:
+            command += ["--no-uid-mod"]
         # ensure ulimit
         command += ["--ulimit", "nofile=%d" % filenumberlimit]
         if fileseeklimit:


### PR DESCRIPTION
This adds a few improvements for executing checks using safe-docker:

* ulimit options also work when using Docker.
* safe-docker can now be used to run checkers even if Praktomat itself is already running inside a Docker container.
* You can specify the path to the safe-docker script through the settings in case it's not available in your `PATH` (see `SAFE_DOCKER_PATH`).
* The name of the image to use can now be specified (see `DOCKER_IMAGE_NAME`). This was previously disabled in the safe-docker script for security reasons. But as far as I know, submissions shouldn't be able to change this parameter. I think the flexibility is worth it when running multiple Praktomat instances on one machine or Docker host.
* Optionally, you can write to the container's filesystem using `DOCKER_CONTAINER_WRITABLE`. This is useful, for example, when the container contains some Gradle projects that contain unit tests. If you check the student's submissions against such tests, Gradle attempts to write to the project directory.
* Optionally, you can also prevent modifying the UID and GID for the user executing checks in the Docker container using `DOCKER_UID_MOD`.

I added the safe-docker script to this repository as the original script is not maintained anymore (see nomeata/safe-docker#3). Therefore, it's probably better if we maintain our own version of this script.

By the way, this is pretty much my first time working with Perl. If you spot any kind of weird code in the safe-docker script, feel free to let me know ;)

The tests don't pass because I didn't merge #348 into this branch.