### PR TITLE
Improve file size limits

### DIFF
--- a/src/solutions/forms.py
+++ b/src/solutions/forms.py
@@ -47,7 +47,8 @@ class SolutionFileForm(ModelForm):
                     zip = zipfile.ZipFile(data)
                     if zip.testzip():
                         raise forms.ValidationError(_('The zip file seems to be corrupt.'))
-                    if sum(fileinfo.file_size for fileinfo in zip.infolist()) > 1000000:
+                    if sum(fileinfo.file_size for fileinfo in zip.infolist()) > max_file_size:
+                        # Protect against zip bombs
                         raise forms.ValidationError(_('The zip file is too big.'))
                     for fileinfo in zip.infolist():
                         filename = fileinfo.filename

--- a/src/solutions/forms.py
+++ b/src/solutions/forms.py
@@ -70,7 +70,7 @@ class SolutionFileForm(ModelForm):
             elif tartype_re.match(contenttype):
                 raise forms.ValidationError(_('Tar files are not supported, please upload the files individually or use a zip file.'))
             if data.size > max_file_size:
-                raise forms.ValidationError(_("The file '%(file)s' is bigger than %(size)KiB which is not suported." %{'file':data.name, 'size':max_file_size_kib}))
+                raise forms.ValidationError(_("The file '%(file)s' is bigger than %(size)d KiB which is not supported." %{'file':data.name, 'size':max_file_size_kib}))
             return data
 
 class MyBaseInlineFormSet(BaseInlineFormSet):

--- a/src/solutions/forms.py
+++ b/src/solutions/forms.py
@@ -29,8 +29,8 @@ class SolutionFileForm(ModelForm):
     def clean_file(self):
         data = self.cleaned_data['file']
         task = self.cleaned_data['solution'].task
-        max_file_size_kb = task.max_file_size
-        max_file_size = 1024 * max_file_size_kb
+        max_file_size_kib = task.max_file_size
+        max_file_size = 1024 * max_file_size_kib
         supported_types_re = re.compile(task.supported_file_types)
         if data:
             contenttype = mimetypes.guess_type(data.name)[0] # don't rely on the browser: data.content_type could be wrong or empty
@@ -61,7 +61,7 @@ class SolutionFileForm(ModelForm):
                             raise forms.ValidationError(_("The plain text file '%(file)s' in this zip file contains a NUL character, which is not supported." %{'file':filename}))
                         # check whole zip instead of contained files
                         #if fileinfo.file_size > max_file_size:
-                        #    raise forms.ValidationError(_("The file '%(file)s' is bigger than %(size)KiB which is not suported." %{'file':fileinfo.filename, 'size':max_file_size_kb}))
+                        #    raise forms.ValidationError(_("The file '%(file)s' is bigger than %(size)KiB which is not suported." %{'file':fileinfo.filename, 'size':max_file_size_kib}))
                 except forms.ValidationError:
                     raise
                 except:
@@ -69,7 +69,7 @@ class SolutionFileForm(ModelForm):
             elif tartype_re.match(contenttype):
                 raise forms.ValidationError(_('Tar files are not supported, please upload the files individually or use a zip file.'))
             if data.size > max_file_size:
-                raise forms.ValidationError(_("The file '%(file)s' is bigger than %(size)KiB which is not suported." %{'file':data.name, 'size':max_file_size_kb}))
+                raise forms.ValidationError(_("The file '%(file)s' is bigger than %(size)KiB which is not suported." %{'file':data.name, 'size':max_file_size_kib}))
             return data
 
 class MyBaseInlineFormSet(BaseInlineFormSet):

--- a/src/tasks/migrations/0010_max_file_size.py
+++ b/src/tasks/migrations/0010_max_file_size.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tasks', '0009_Task_dynamic_upload_waiting_time_Python3_Python2'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='task',
+            name='max_file_size',
+            field=models.IntegerField(default=1000, help_text='The maximum size of an uploaded solution file in kibibyte.'),
+        ),
+    ]

--- a/src/tasks/models.py
+++ b/src/tasks/models.py
@@ -36,7 +36,7 @@ class Task(models.Model):
     submission_maxpossible = models.IntegerField(default=-1,help_text=_("Number of uploads a user can submit for the same task. Value -1 means unlimited")) 	
 
     supported_file_types = models.CharField(max_length=1000, default ="^(text/.*|image/.*|application/pdf)$", help_text = _("Regular Expression describing the mime types of solution files that the user is allowed to upload."))
-    max_file_size = models.IntegerField(default=1000, help_text = _("The maximum size of an uploaded solution file in kilobyte."))
+    max_file_size = models.IntegerField(default=1000, help_text = _("The maximum size of an uploaded solution file in kibibyte."))
     model_solution = models.ForeignKey('solutions.Solution', on_delete=models.SET_NULL, blank=True, null=True, related_name='model_solution_task')
     all_checker_finished = models.BooleanField(default=False, editable=False, help_text = _("Indicates whether the checker which don't run immediately on submission have been executed."))
     final_grade_rating_scale = models.ForeignKey('attestation.RatingScale', on_delete=models.SET_NULL, null=True, help_text = _("The scale used to mark the whole solution."))


### PR DESCRIPTION
This allows submitting a zip file larger than 1 MB. Until now, there was a hard-coded limitation of 1 MB in the size of the sum of the file sizes in an uploaded zip file. The goal was to prevent accepting zip bombs. However, this limit can sometimes be exceeded when the zip file contains images or PDF files. To keep things simple, using the same limit as for the maximum file size is probably fine, in my opinion, and serves the purpose.

Additionally, I fixed the following:
- The unit displayed for `max_file_size` was technically incorrect. As we're multiplying by 1024, the correct unit is kibibyte.
- The error message for exceeding the maximum file size contained an error itself. The format character was missing and there was a typo in the word "supported".

Again: the tests don't pass because I didn't merge #348 into this branch.