### PR TITLE
Small bugfix for src/settings/local.py handling NameError.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Python 3.5
 General setup
 =============
 
-You need the latest version that is compatible with the Python version used. 
+You need the latest version that is compatible with the Python version used.
 We also highly recommend to use virtualenv so your system Python installation remains clean.
 
 If you are having trouble with
@@ -189,7 +189,7 @@ Python installation or inside a designated virtualenv (recommended).
 The following describes a recommended setup using virtualenv.
 
 ```bash
-git clone --recursive git://github.com/KITPraktomatTeam/Praktomat.git
+git clone --recursive https://github.com/KITPraktomatTeam/Praktomat.git
 virtualenv -p python3 --system-site-packages env/
 . env/bin/activate
 pip install -U pip virtualenv setuptools wheel urllib3[secure]
@@ -239,7 +239,7 @@ Deployment installation
 Like for the development version, clone the Praktomat and install its dependencies:
 
 ```bash
-git clone --recursive git://github.com/KITPraktomatTeam/Praktomat.git
+git clone --recursive https://github.com/KITPraktomatTeam/Praktomat.git
 virtualenv -p python3 --system-site-packages env/
 . env/bin/activate
 pip install -U pip virtualenv setuptools wheel urllib3[secure]
@@ -370,7 +370,7 @@ To access the praktomat usersessions from an phpBB follow the instructions in `s
 CUnit CPPUnit Checker
 =================
 
-For configuration please have a look into README_feature_CUnitCppUnit_Checker.txt.
+For configuration please have a look into `README_feature_CUnitCppUnit_Checker.txt`.
 
 
 [Bug tracker]: https://github.com/KITPraktomatTeam/Praktomat/issues

--- a/src/settings/local.py
+++ b/src/settings/local.py
@@ -66,7 +66,6 @@ if match:
 else:
     raise NotImplementedError("Autoconfig for PRAKTOMAT_ID %s not possible", PRAKTOMAT_ID)
 
-
 # The URL where this site is reachable. 'http://localhost:8000/' in case of the
 # development server.
 BASE_HOST = 'https://praktomat.cs.kit.edu'
@@ -124,6 +123,8 @@ ADMINS = [
 
 SERVER_EMAIL = 'praktomat@i44vm3.info.uni-karlsruhe.de'
 
+try: MIRROR
+except NameError: MIRROR = False
 
 if MIRROR:
     EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
@@ -228,7 +229,7 @@ MOD_XSENDFILE_V1_0 = True
 # Our VM has 4 cores, so lets try to use them
 NUMBER_OF_TASKS_TO_BE_CHECKED_IN_PARALLEL = 6
 # But not with Isabelle, which is memory bound
-if match.group('tba') is not None:
+if match and match.group('tba') is not None:
     NUMBER_OF_TASKS_TO_BE_CHECKED_IN_PARALLEL = 1
 
 


### PR DESCRIPTION
set a default value for `MIRROR` if NameError has been found.
first check if `match` is  not none before accessing `match.group(...)`

Edit: 
the tests (py3.6 to py3.10) don't pass because I didn't merge https://github.com/KITPraktomatTeam/Praktomat/pull/348 into this branch.
the test (py3.5) don't pass because of `SystemError: ffi_prep_closure(): bad user_data (it seems that the version of the libffi library seen at runtime is different from the 'ffi.h' file seen at compile-time)`