### PR TITLE
New Emailing Settings 

### DIFF
--- a/src/accounts/forms.py
+++ b/src/accounts/forms.py
@@ -104,11 +104,13 @@ class UserChangeForm(forms.ModelForm):
     # overriding modelfields to ensure required fields are provided
     first_name = forms.CharField(max_length = 30, required=True)
     last_name = forms.CharField(max_length = 30, required=True)
+    attestationEmails = forms.BooleanField(help_text="recive Email for each task attestation.", required=False)
+    uploadConfirmEmails = forms.BooleanField(help_text="recive submission Email for each upload.", required=False)
     #email = forms.EmailField(required=True)
 
     class Meta:
         model = User
-        fields = ("first_name", "last_name")
+        fields = ("first_name", "last_name", "attestationEmails", "uploadConfirmEmails")
 
 
 class AdminUserCreationForm(UserBaseCreationForm):

--- a/src/accounts/forms.py
+++ b/src/accounts/forms.py
@@ -104,8 +104,8 @@ class UserChangeForm(forms.ModelForm):
     # overriding modelfields to ensure required fields are provided
     first_name = forms.CharField(max_length = 30, required=True)
     last_name = forms.CharField(max_length = 30, required=True)
-    attestation_emails = forms.BooleanField(help_text="recive Email for each task attestation.", required=False)
-    upload_confirm_emails = forms.BooleanField(help_text="recive submission Email for each upload.", required=False)
+    attestation_emails = forms.BooleanField(help_text="Receive a confirmation email for each task that has been attested.", required=False)
+    upload_confirm_emails = forms.BooleanField(help_text="Recive a confirmation Email for each file that has been uploaded.", required=False)
     #email = forms.EmailField(required=True)
 
     class Meta:

--- a/src/accounts/forms.py
+++ b/src/accounts/forms.py
@@ -104,13 +104,13 @@ class UserChangeForm(forms.ModelForm):
     # overriding modelfields to ensure required fields are provided
     first_name = forms.CharField(max_length = 30, required=True)
     last_name = forms.CharField(max_length = 30, required=True)
-    attestationEmails = forms.BooleanField(help_text="recive Email for each task attestation.", required=False)
-    uploadConfirmEmails = forms.BooleanField(help_text="recive submission Email for each upload.", required=False)
+    attestation_emails = forms.BooleanField(help_text="recive Email for each task attestation.", required=False)
+    upload_confirm_emails = forms.BooleanField(help_text="recive submission Email for each upload.", required=False)
     #email = forms.EmailField(required=True)
 
     class Meta:
         model = User
-        fields = ("first_name", "last_name", "attestationEmails", "uploadConfirmEmails")
+        fields = ("first_name", "last_name", "attestation_emails", "upload_confirm_emails")
 
 
 class AdminUserCreationForm(UserBaseCreationForm):

--- a/src/accounts/models.py
+++ b/src/accounts/models.py
@@ -42,10 +42,10 @@ class User(BasicUser):
     activation_key=models.CharField(_('activation key'), max_length=40, editable=False)
     user_text=models.CharField(null=True, blank=True, max_length=500, help_text = _("Custom text which will be shown to this student."))
     accepted_disclaimer=models.BooleanField(default=False, help_text="Whether the user accepted the disclaimer.")
-    #'attestationEmails' to check whether the user wishes to receive an email notification for each attestation.
-    attestationEmails = models.BooleanField(default=True, help_text="recive confirmation Email for each task has been attested.")
-    #'uploadConfirmEmails' to check whether the user wishes to receive an email notification for each upload they make.
-    uploadConfirmEmails = models.BooleanField(default=False, help_text="recive confirmation Email for each file has been uploaded.")
+    #'attestation_emails' to check whether the user wishes to receive an email notification for each attestation.
+    attestation_emails = models.BooleanField(default=True, help_text="recive confirmation Email for each task has been attested.")
+    #'upload_confirm_emails' to check whether the user wishes to receive an email notification for each upload they make.
+    upload_confirm_emails = models.BooleanField(default=False, help_text="recive confirmation Email for each file has been uploaded.")
 
     # Use UserManager to get the create_user method, etc.
     objects = UserManager()

--- a/src/accounts/models.py
+++ b/src/accounts/models.py
@@ -42,6 +42,10 @@ class User(BasicUser):
     activation_key=models.CharField(_('activation key'), max_length=40, editable=False)
     user_text=models.CharField(null=True, blank=True, max_length=500, help_text = _("Custom text which will be shown to this student."))
     accepted_disclaimer=models.BooleanField(default=False, help_text="Whether the user accepted the disclaimer.")
+    #'attestationEmails' to check whether the user wishes to receive an email notification for each attestation.
+    attestationEmails = models.BooleanField(default=True, help_text="recive confirmation Email for each task has been attested.")
+    #'uploadConfirmEmails' to check whether the user wishes to receive an email notification for each upload they make.
+    uploadConfirmEmails = models.BooleanField(default=False, help_text="recive confirmation Email for each file has been uploaded.")
 
     # Use UserManager to get the create_user method, etc.
     objects = UserManager()

--- a/src/accounts/models.py
+++ b/src/accounts/models.py
@@ -42,10 +42,10 @@ class User(BasicUser):
     activation_key=models.CharField(_('activation key'), max_length=40, editable=False)
     user_text=models.CharField(null=True, blank=True, max_length=500, help_text = _("Custom text which will be shown to this student."))
     accepted_disclaimer=models.BooleanField(default=False, help_text="Whether the user accepted the disclaimer.")
-    #'attestation_emails' to check whether the user wishes to receive an email notification for each attestation.
-    attestation_emails = models.BooleanField(default=True, help_text="recive confirmation Email for each task has been attested.")
-    #'upload_confirm_emails' to check whether the user wishes to receive an email notification for each upload they make.
-    upload_confirm_emails = models.BooleanField(default=False, help_text="recive confirmation Email for each file has been uploaded.")
+    #'attestation_emails' to check whether the user wishes to receive an email notification for each task attestation.
+    attestation_emails = models.BooleanField(default=True, help_text="Receive a confirmation email for each task that has been attested.")
+    #'upload_confirm_emails' to check whether the user wishes to receive an email notification for each file upload they make.
+    upload_confirm_emails = models.BooleanField(default=False, help_text="Recive a confirmation Email for each file has been uploaded.")
 
     # Use UserManager to get the create_user method, etc.
     objects = UserManager()

--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -69,29 +69,22 @@ def change(request):
         form = UserChangeForm(request.POST, instance=request.user)
         if form.is_valid():
             form.save()
-            #to get the value of the 'attestationEmails' checkbox.
-            attestationEmails = request.POST.get('attestationEmails')
+            #to get the value of the 'attestation_emails' checkbox.
+            attestation_emails = request.POST.get('attestation_emails')
             #to change the values of the value of the checkbox to 'True' or 'False'
-            is_checked = bool(attestationEmails)
+            is_checked = bool(attestation_emails)
             if is_checked:
-                attestationEmails = 'True'
+                attestation_emails = 'True'
             else:
-                attestationEmails = 'False'
-            #to get the value of the 'uploadConfirmEmails' checkbox.
-            uploadConfirmEmails = request.POST.get('uploadConfirmEmails')
+                attestation_emails = 'False'
+            #to get the value of the 'upload_confirm_emails' checkbox.
+            upload_confirm_emails = request.POST.get('upload_confirm_emails')
             #to change the values of the value of the checkbox to 'True' or 'False'
-            is_checked = bool(uploadConfirmEmails)
+            is_checked = bool(upload_confirm_emails)
             if is_checked:
-                uploadConfirmEmails = 'True'
+                upload_confirm_emails = 'True'
             else:
-                uploadConfirmEmails = 'False'
-            #to save the values of the 'attestationEmails' and 'uploadConfirmEmails' checkboxes.
-            user = form.save(commit=False)
-            attestationEmails = form.cleaned_data['attestationEmails']
-            uploadConfirmEmails = form.cleaned_data['uploadConfirmEmails']
-            user.attestationEmails = attestationEmails
-            user.uploadConfirmEmails = uploadConfirmEmails
-            user.save()
+                upload_confirm_emails = 'False'
             return HttpResponseRedirect(reverse('task_list'))
     else:
         form = UserChangeForm(instance=request.user)

--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -69,6 +69,29 @@ def change(request):
         form = UserChangeForm(request.POST, instance=request.user)
         if form.is_valid():
             form.save()
+            #to get the value of the 'attestationEmails' checkbox.
+            attestationEmails = request.POST.get('attestationEmails')
+            #to change the values of the value of the checkbox to 'True' or 'False'
+            is_checked = bool(attestationEmails)
+            if is_checked:
+                attestationEmails = 'True'
+            else:
+                attestationEmails = 'False'
+            #to get the value of the 'uploadConfirmEmails' checkbox.
+            uploadConfirmEmails = request.POST.get('uploadConfirmEmails')
+            #to change the values of the value of the checkbox to 'True' or 'False'
+            is_checked = bool(uploadConfirmEmails)
+            if is_checked:
+                uploadConfirmEmails = 'True'
+            else:
+                uploadConfirmEmails = 'False'
+            #to save the values of the 'attestationEmails' and 'uploadConfirmEmails' checkboxes.
+            user = form.save(commit=False)
+            attestationEmails = form.cleaned_data['attestationEmails']
+            uploadConfirmEmails = form.cleaned_data['uploadConfirmEmails']
+            user.attestationEmails = attestationEmails
+            user.uploadConfirmEmails = uploadConfirmEmails
+            user.save()
             return HttpResponseRedirect(reverse('task_list'))
     else:
         form = UserChangeForm(instance=request.user)

--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -69,22 +69,13 @@ def change(request):
         form = UserChangeForm(request.POST, instance=request.user)
         if form.is_valid():
             form.save()
-            #to get the value of the 'attestation_emails' checkbox.
-            attestation_emails = request.POST.get('attestation_emails')
-            #to change the values of the value of the checkbox to 'True' or 'False'
-            is_checked = bool(attestation_emails)
-            if is_checked:
-                attestation_emails = 'True'
-            else:
-                attestation_emails = 'False'
-            #to get the value of the 'upload_confirm_emails' checkbox.
-            upload_confirm_emails = request.POST.get('upload_confirm_emails')
-            #to change the values of the value of the checkbox to 'True' or 'False'
-            is_checked = bool(upload_confirm_emails)
-            if is_checked:
-                upload_confirm_emails = 'True'
-            else:
-                upload_confirm_emails = 'False'
+            #to save the values of the 'attestation_emails' and 'upload_confirm_emails' checkboxes.
+            user = form.save(commit=False)
+            attestation_emails = form.cleaned_data['attestation_emails']
+            upload_confirm_emails = form.cleaned_data['upload_confirm_emails']
+            user.attestation_emails = attestation_emails
+            user.upload_confirm_emails = upload_confirm_emails
+            user.save()
             return HttpResponseRedirect(reverse('task_list'))
     else:
         form = UserChangeForm(instance=request.user)

--- a/src/attestation/models.py
+++ b/src/attestation/models.py
@@ -65,7 +65,9 @@ class Attestation(models.Model):
                  + ([get_settings().attestation_reply_to]  if get_settings().attestation_reply_to else [])
         headers = {'Reply-To': ', '.join(reply_to)} if reply_to else None
         email = EmailMessage(subject, body, None, (email,), headers = headers)
-        email.send()
+        #to check if the user has selected the checkbox on the 'Change Account' page to confirm their willingness to receive attestation emails ('True' by default)
+        if User.attestationEmails:
+            email.send()
 
     def withdraw(self, request, by):
         self.published = False

--- a/src/attestation/models.py
+++ b/src/attestation/models.py
@@ -65,7 +65,8 @@ class Attestation(models.Model):
                  + ([get_settings().attestation_reply_to]  if get_settings().attestation_reply_to else [])
         headers = {'Reply-To': ', '.join(reply_to)} if reply_to else None
         email = EmailMessage(subject, body, None, (email,), headers = headers)
-        #to check if the user has selected the checkbox on the 'Change Account' page to confirm their willingness to receive attestation emails ('True' by default)
+        #to check if the user has selected the checkbox on the 'Change Account' page to confirm 
+        #their willingness to receive attestation emails ('True' by default)
         if User.attestation_emails:
             email.send()
 

--- a/src/attestation/models.py
+++ b/src/attestation/models.py
@@ -66,7 +66,7 @@ class Attestation(models.Model):
         headers = {'Reply-To': ', '.join(reply_to)} if reply_to else None
         email = EmailMessage(subject, body, None, (email,), headers = headers)
         #to check if the user has selected the checkbox on the 'Change Account' page to confirm their willingness to receive attestation emails ('True' by default)
-        if User.attestationEmails:
+        if User.attestation_emails:
             email.send()
 
     def withdraw(self, request, by):

--- a/src/solutions/views.py
+++ b/src/solutions/views.py
@@ -168,7 +168,8 @@ def solution_list(request, task_id, user_id=None):
                          message.send() # any PY2-PY3 problem in here ?
 
                 else: #we are sending unsigned email
-                    #one of the checks is: if the user has selected the checkbox on the 'Change Account' page to confirm their willingness to receive an email fo each file upload ('False' by default)
+                    #one of the checks is: if the user has selected the checkbox on the 'Change Account' page to confirm 
+                    #their willingness to receive an email fo each file upload ('False' by default)
                     if solution.author.email and User.upload_confirm_emails:
                          send_mail(_("%s submission confirmation") % settings.SITE_NAME, t.render(c), None, [solution.author.email])
 

--- a/src/solutions/views.py
+++ b/src/solutions/views.py
@@ -168,7 +168,8 @@ def solution_list(request, task_id, user_id=None):
                          message.send() # any PY2-PY3 problem in here ?
 
                 else: #we are sending unsigned email
-                    if solution.author.email:
+                    #one of the checks is: if the user has selected the checkbox on the 'Change Account' page to confirm their willingness to receive an email fo each file upload ('False' by default)
+                    if solution.author.email and User.uploadConfirmEmails:
                          send_mail(_("%s submission confirmation") % settings.SITE_NAME, t.render(c), None, [solution.author.email])
 
             return HttpResponseRedirect(reverse('solution_detail', args=[solution.id]))

--- a/src/solutions/views.py
+++ b/src/solutions/views.py
@@ -169,7 +169,7 @@ def solution_list(request, task_id, user_id=None):
 
                 else: #we are sending unsigned email
                     #one of the checks is: if the user has selected the checkbox on the 'Change Account' page to confirm their willingness to receive an email fo each file upload ('False' by default)
-                    if solution.author.email and User.uploadConfirmEmails:
+                    if solution.author.email and User.upload_confirm_emails:
                          send_mail(_("%s submission confirmation") % settings.SITE_NAME, t.render(c), None, [solution.author.email])
 
             return HttpResponseRedirect(reverse('solution_detail', args=[solution.id]))

--- a/src/solutions/views.py
+++ b/src/solutions/views.py
@@ -164,7 +164,7 @@ def solution_list(request, task_id, user_id=None):
 
                     connection = get_connection()
                     message = ConfirmationMessage(_("%s submission confirmation") % settings.SITE_NAME, signed_mail, None, [solution.author.email], connection=connection)
-                    if solution.author.email:
+                    if solution.author.email and User.upload_confirm_emails:
                          message.send() # any PY2-PY3 problem in here ?
 
                 else: #we are sending unsigned email


### PR DESCRIPTION
Implementing customizable email settings that allow users to select whether they wish to receive confirmation emails or not.
By default, the 'upload_confirm_emails' checkbox, which allows users to opt-in to receive email notifications for each file upload they make, is set to 'False'. However, the 'attestation_emails' checkbox, which allows users to opt-in to receive email notifications for each task attestation, is set to 'True' by default.
