### PR TITLE
Remove Java's Security Manager deprecation message from Checker-Outputs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Python 3.5
 General setup
 =============
 
-You need the latest version that is compatible with the Python version used. 
+You need the latest version that is compatible with the Python version used.
 We also highly recommend to use virtualenv so your system Python installation remains clean.
 
 If you are having trouble with
@@ -319,7 +319,7 @@ Security
 ========
 
 Besides the security provided by Java (via the Security Manager Profiles found
-in `src/checker/scripts/`), the praktomat supports two way to insulate student
+in `src/checker/scripts/`, which you could change to your needs), the praktomat supports two way to insulate student
 submissions from the system:
 
  * With `USEPRAKTOMATTESTER = True` in the settings, external commands are

--- a/src/checker/checker/DejaGnu.py
+++ b/src/checker/checker/DejaGnu.py
@@ -137,6 +137,11 @@ class DejaGnuTester(Checker, DejaGnu):
                         extradirs=[env.tmpdir(), script_dir]
                         )
         output = encoding.get_unicode(output)
+        #TODO this is just a workaround for the deprecation of Java Security Manager (since java 17)
+        # the warnings occur because the java (alias-)script ../scripts/java that is called by Praktomat sets the command line option to use java security manager
+        # problem is that these warning occur also in the output of the JUnit-checker and irritate the students
+        output = output.replace("WARNING: A command line option has enabled the Security Manager\n","")
+        output = output.replace("WARNING: The Security Manager is deprecated and will be removed in a future release\n","")
 
         try:
             with open(os.path.join(testsuite, program_name + ".sum"),"rb") as fd:

--- a/src/checker/checker/DiffChecker.py
+++ b/src/checker/checker/DiffChecker.py
@@ -25,12 +25,12 @@ class DiffChecker(Checker):
     shell_script = CheckerFileField(help_text=_("The shell script whose output for the given input file is compared to the given output file: The substrings JAVA and PROGRAM got replaced by Praktomat determined values."))
     input_file = CheckerFileField(blank=True, help_text=_("The file containing the input for the program."))
     output_file = CheckerFileField(blank=True, help_text=_("The file containing the output for the program."))
-        
-    
+
+
     def clean(self):
         super(DiffChecker, self).clean()
         if (not self.shell_script or not self.input_file or not self.output_file): raise ValidationError("Robert says: DiffChecker have to have an Shell script, an Inputfile and an Outputfile")
-    
+
     def title(self):
         """ Returns the title for this checker category. """
         return u"Ausgaben mit 'diff' prüfen."
@@ -39,14 +39,14 @@ class DiffChecker(Checker):
     def description():
         """ Returns a description for this Checker. """
         return u"Diese Prüfung wird bestanden, wenn erwartete und tatsächliche Ausgabe übereinstimmen."
-    
+
     def run(self, env):
-        """ Runs tests in a special environment. Here's the actual work. 
+        """ Runs tests in a special environment. Here's the actual work.
         This runs the check in the environment ENV, returning a CheckerResult. """
 
         # Setup
         test_dir     = env.tmpdir()
-        environ = {}      
+        environ = {}
         if self.input_file:
             input_path = os.path.join(test_dir, os.path.basename(self.input_file.path))
             environ['INPUTFILE'] = os.path.basename(self.input_file.path)
@@ -57,9 +57,9 @@ class DiffChecker(Checker):
             copy_file(self.output_file.path, output_path)
         replace = [(u'PROGRAM',env.program())] if env.program() else []
         replace +=[("JAVA",settings.JVM_SECURE)]
-        #copy_file_to_directory(self.shell_script.path, test_dir, replace=replace)                
+        #copy_file_to_directory(self.shell_script.path, test_dir, replace=replace)
         copy_file(self.shell_script.path, test_dir, to_is_directory=True)
-        
+
         #some time after 2013 Praktomat losts copy_file_to_directory with replace parameter
         to_path = os.path.join(test_dir, os.path.basename(self.shell_script.path))
         with open(to_path) as fd:
@@ -68,18 +68,18 @@ class DiffChecker(Checker):
                         content = content.replace(old, new)
         with open(to_path, 'w') as fd:
                 fd.write(encoding.get_utf8(content))
-        
-        
+
+
         args = ["sh",  os.path.basename(self.shell_script.name)]
         #environ['USER'] = unicode(env.user().get_full_name()).encode('utf-8')
         environ['USER'] = env.user().username # gets overwritten with praktomat-test-user's name, therefore:
         environ['AUTHOR'] = env.solution().author.username # will not be overwritten!
         environ['HOME'] = test_dir
-        
+
         script_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)),'scripts')
-        
+
         #[output, error, exitcode,_] = execute_arglist(args, working_directory=test_dir, environment_variables=environ)
-               
+
         [output, error, exitcode,timed_out, oom_ed] = execute_arglist(
                             args,
                             working_directory=test_dir,
@@ -91,16 +91,20 @@ class DiffChecker(Checker):
                             extradirs = [script_dir],
                             )
         output = force_unicode(output, errors='replace')
-        
-        
+        #TODO this is just a workaround for the deprecation of Java Security Manager (since java 17)
+        # the warnings occur because the java (alias-)script ../scripts/java that is called by Praktomat sets the command line option to use java security manager
+        # problem is that these warning occur also in the output of the JUnit-checker and irritate the students
+        output = output.replace("WARNING: A command line option has enabled the Security Manager\n","")
+        output = output.replace("WARNING: The Security Manager is deprecated and will be removed in a future release\n","")
+
         result = CheckerResult(checker=self, solution=env.solution())
 
         result.set_log('<pre>' + escape(output) + '</pre>')
 
         result.set_passed(not exitcode)
-        
+
         return result
-    
+
 
 from checker.admin import    CheckerInline
 

--- a/src/checker/checker/JUnitChecker.py
+++ b/src/checker/checker/JUnitChecker.py
@@ -91,6 +91,12 @@ class JUnitChecker(Checker):
         (output, truncated) = truncated_log(output)
         output = '<pre>' + escape(self.test_description) + '\n\n======== Test Results ======\n\n</pre><br/><pre>' + escape(output) + '</pre>'
 
+        #TODO this is just a workaround for the deprecation of Java Security Manager (since java 17)
+        # the warnings occur because the java (alias-)script ../scripts/java that is called by Praktomat sets the command line option to use java security manager
+        # problem is that these warning occur also in the output of the JUnit-checker and irritate the students
+        output = output.replace("WARNING: A command line option has enabled the Security Manager\n","")
+        output = output.replace("WARNING: The Security Manager is deprecated and will be removed in a future release\n","")
+
 
         result.set_log(output, timed_out=timed_out or oom_ed, truncated=truncated, oom_ed=oom_ed)
         result.set_passed(not exitcode and not timed_out and not oom_ed and self.output_ok(output) and not truncated)

--- a/src/checker/checker/JavaChecker.py
+++ b/src/checker/checker/JavaChecker.py
@@ -49,7 +49,7 @@ class JavaChecker(Checker):
 
         script_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'scripts')
         environ['POLICY'] = os.path.join(script_dir, "junit.policy")
-        cmd = [settings.JVM_SECURE, "-cp", settings.JAVA_CUSTOM_LIBS + ":*", self.class_name, 
+        cmd = [settings.JVM_SECURE, "-cp", settings.JAVA_CUSTOM_LIBS + ":*", self.class_name,
             env.tmpdir(),
             str(env.user().id),
             str(env.user().mat_number),
@@ -58,12 +58,17 @@ class JavaChecker(Checker):
             str(env.solution().id)]
         [output, error, exitcode, timed_out, oom_ed] = execute_arglist(cmd, env.tmpdir(), environment_variables=environ,
             timeout=settings.TEST_TIMEOUT, fileseeklimit=settings.TEST_MAXFILESIZE, filenumberlimit=settings.TEST_MAXFILENUMBER, extradirs=[script_dir])
-
         result = self.create_result(env)
 
         (output, truncated) = truncated_log(output)
         output = '<pre>' + escape(self.test_description) + '\n\n======== Test Results ======\n\n</pre><br/><pre>' + \
                  escape(output) + '</pre>'
+
+        #TODO this is just a workaround for the deprecation of Java Security Manager (since java 17)
+        # the warnings occur because the java (alias-)script ../scripts/java that is called by Praktomat sets the command line option to use java security manager
+        # problem is that these warning occur also in the output of the JUnit-checker and irritate the students
+        output = output.replace("WARNING: A command line option has enabled the Security Manager\n","")
+        output = output.replace("WARNING: The Security Manager is deprecated and will be removed in a future release\n","")
         result.set_log(output, timed_out=timed_out or oom_ed, truncated=truncated, oom_ed=oom_ed)
         result.set_passed(not exitcode and not timed_out and not oom_ed and self.output_ok(output) and not truncated)
         return result

--- a/src/checker/checker/ScriptChecker.py
+++ b/src/checker/checker/ScriptChecker.py
@@ -88,6 +88,13 @@ class ScriptChecker(Checker):
         if not self.returns_html or truncated or timed_out or oom_ed:
             output = '<pre>' + escape(output) + '</pre>'
 
+
+        #TODO this is just a workaround for the deprecation of Java Security Manager (since java 17)
+        # the warnings occure because the java (alis-)script ../scripts/java that is called by Praktomat sets the command line to use java security manager
+        # problem is that these warning occure also in the output of the TestFW started by ScriptChecker and irritate the students.
+        output = output.replace("WARNING: A command line option has enabled the Security Manager\n","")
+        output = output.replace("WARNING: The Security Manager is deprecated and will be removed in a future release\n","")
+
         result.set_log(output, timed_out=timed_out, truncated=truncated, oom_ed=oom_ed)
         result.set_passed(not exitcode and not timed_out and not oom_ed and not truncated)
 

--- a/src/checker/scripts/java.policy
+++ b/src/checker/scripts/java.policy
@@ -17,7 +17,8 @@ grant {
 };
 
 // Settings for own java-based TestFrameworks started via ScriptChecker ... perhaps switch to use JavaChecker and junit.policy
-
+// The following block can be seen as an example how to configure an own java based Testframework.
+/*
 grant codeBase "file:TestRunner.jar" {
         permission java.lang.RuntimePermission "createClassLoader";
         permission java.util.PropertyPermission "user.dir", "read"; // get current working dir
@@ -38,4 +39,4 @@ grant codeBase "file:TestSuite.jar" {
     // TypeChecks
     permission java.lang.RuntimePermission "accessDeclaredMembers";
 };
-
+*/

--- a/src/checker/scripts/java.policy
+++ b/src/checker/scripts/java.policy
@@ -1,6 +1,41 @@
 // Default java policy for the praktomat
-// Set as $POLICY by ScriptChecker and used by ./src/checker/scripts/java
+// Set as $POLICY by ScriptChecker and DejaGnuChecker via settings.JVM_POLICY and used by ./src/checker/scripts/java
 grant {
+// If Java (and student solutions) should be allowed to read the temporary created working directory, than activate the following three lines:
+//        permission java.util.PropertyPermission "user.dir", "read"; // user.dir contains the name of a temporary folder inside work-data/SolutionSandbox
+//        permission java.io.FilePermission "${user.dir}" , "read";   // allow to read user.dir, where uploaded files were stored temporary
+//        permission java.io.FilePermission "${user.dir}${/}-" , "read"; // allow to read directory and recursivly all files and subdirectories
+//// Following information about special pathnames taken from Java 18 API class FilePermission:
+////      permission java.io.FilePermission "*" , "read"; // read all files in current directory
+////      permission java.io.FilePermission "-", "read";  // read all files in current directory and recursivly all files and subdirectories
+////      permission java.io.FilePermission "<<ALL FILES>>", "read"; // read all files on disc ...
+
+///////////////
+
 	permission java.lang.RuntimePermission "shutdownHooks";
-	permission java.lang.RuntimePermission "setIO";
+	permission java.lang.RuntimePermission "setIO"; // change sysout, stderr, stdin
 };
+
+// Settings for own java-based TestFrameworks started via ScriptChecker ... perhaps switch to use JavaChecker and junit.policy
+
+grant codeBase "file:TestRunner.jar" {
+        permission java.lang.RuntimePermission "createClassLoader";
+        permission java.util.PropertyPermission "user.dir", "read"; // get current working dir
+        permission java.io.FilePermission "${user.dir}" , "read";
+        permission java.io.FilePermission "${user.dir}${/}-" , "read";
+// Following information about special pathnames taken from Java 18 API class FilePermission:
+//      permission java.io.FilePermission "*" , "read"; // read all files in current directory
+        permission java.io.FilePermission "-", "read";  // read all files in current directory and recursivly all files and subdirectories
+//      permission java.io.FilePermission "<<ALL FILES>>", "read"; // read all files on disc ...
+        permission java.io.FilePermission "debug.log", "write";
+        permission java.lang.RuntimePermission "setIO"; // change sysout, stderr, stdin
+};
+
+grant codeBase "file:TestSuite.jar" {
+    // TestIO
+    permission java.lang.RuntimePermission "setIO";                 // change sysout, syserr & sysin
+
+    // TypeChecks
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
+};
+

--- a/src/checker/scripts/javac
+++ b/src/checker/scripts/javac
@@ -10,6 +10,10 @@
 #
 # Da der Praktomat als suid praktomat läuft,...
 
+# using *-sandbox.jar has been removed some years ago,
+# but you can recreate and use them,
+# see : https://github.com/KITPraktomatTeam/Praktomat/issues/350#issuecomment-1234011974
+
 if [ ! -n "$JAVAC" ]
 then
    JAVAC=javac

--- a/src/checker/scripts/junit.policy
+++ b/src/checker/scripts/junit.policy
@@ -27,7 +27,8 @@ grant {
 };
 
 // Settings for own java-based TestFrameworks started via JUnitChecker or JavaChecker
-
+// The following block can be seen as an example how to configure an own java based Testframework.
+/*
 grant codeBase "file:db-checker-praktomat-1.0-SNAPSHOT.jar" {
         permission java.lang.RuntimePermission "loadLibrary.dbm_core";
         permission java.lang.RuntimePermission "createClassLoader";
@@ -41,3 +42,4 @@ grant codeBase "file:db-checker-praktomat-1.0-SNAPSHOT.jar" {
         permission java.io.FilePermission "debug.log", "write";
         permission java.lang.RuntimePermission "setIO"; // change sysout, stderr, stdin
 };
+*/

--- a/src/checker/scripts/junit.policy
+++ b/src/checker/scripts/junit.policy
@@ -1,8 +1,14 @@
+// Set as $POLICY and used by Praktomat's JUnitChecker.py , JavaChecker.py : interaction with ./src/checker/scripts/java
 grant {
 	permission java.util.PropertyPermission "user.home","read";
 	permission java.io.FilePermission "/home/praktomat/junit.properties", "read";
 	permission java.io.FilePermission "/home/tester/junit.properties", "read";
-	permission java.io.FilePermission "${user.dir}${/}data${/}-", "read";            // user.dir is the current working directory where JVM was started. , see https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html
+
+	// user.dir is the current working directory where JVM was started. , see https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html
+        permission java.util.PropertyPermission "user.dir", "read"; /// user.dir contains the name of a temporary folder inside work-data/SolutionSandbox
+        permission java.io.FilePermission "${user.dir}" , "read";   // allow to read user.dir, where uploaded files were stored temporary
+        permission java.io.FilePermission "${user.dir}${/}-" , "read"; // allow to read directory and recursivly all files and subdirectories
+
 	permission java.lang.RuntimePermission "accessDeclaredMembers";
 	permission java.lang.RuntimePermission "getStackTrace";
 
@@ -18,5 +24,20 @@ grant {
 	//to enable JUNIT and JUNIT-PARAMS Tests for nested unnamed classes
 	permission java.lang.RuntimePermission "createSecurityManager";
 	permission java.lang.RuntimePermission "setSecurityManager";
-	permission java.io.FilePermission "/home/praktomat/inst/2021t/work-data/SolutionSandbox/*", "read"; //TODO: update for every instance: how we can do this more generic?
+};
+
+// Settings for own java-based TestFrameworks started via JUnitChecker or JavaChecker
+
+grant codeBase "file:db-checker-praktomat-1.0-SNAPSHOT.jar" {
+        permission java.lang.RuntimePermission "loadLibrary.dbm_core";
+        permission java.lang.RuntimePermission "createClassLoader";
+        permission java.util.PropertyPermission "user.dir", "read"; // get current working dir
+        permission java.io.FilePermission "${user.dir}" , "read";
+        permission java.io.FilePermission "${user.dir}${/}-" , "read";
+//        Following information about special pathnames taken from Java 18 API class FilePermission:
+//        permission java.io.FilePermission "*" , "read"; // read all files in current directory
+        permission java.io.FilePermission "-", "read";  // read all files in current directory and recursivly all files and subdirectories
+//        permission java.io.FilePermission "<<ALL FILES>>", "read"; // read all files on disc ...
+        permission java.io.FilePermission "debug.log", "write";
+        permission java.lang.RuntimePermission "setIO"; // change sysout, stderr, stdin
 };


### PR DESCRIPTION
- Remove Java's Security Manager deprecation message from Checker-Outputs.
- add some documentation information into java.policy and junit.policy 
- related to https://github.com/KITPraktomatTeam/Praktomat/issues/350 
- related to https://github.com/KITPraktomatTeam/Praktomat/issues/307 

close https://github.com/KITPraktomatTeam/Praktomat/issues/307