### PR TITLE
fix test case test_dejagnu_checker

### DIFF
--- a/src/checker/tests.py
+++ b/src/checker/tests.py
@@ -266,7 +266,7 @@ class TestChecker(TestCase):
         copy_file(src, test_defs)
         DejaGnu.DejaGnuSetup.objects.create(
                     task = self.task,
-                    order = 1,
+                    order = 2,
                     test_defs = test_defs
                     )
         src = join(dirname(dirname(dirname(__file__))), 'examples', 'Tasks', 'GGT', 'DejaGnuTestCases', 'public.exp')
@@ -275,7 +275,7 @@ class TestChecker(TestCase):
         copy_file(src, test_case)
         DejaGnu.DejaGnuTester.objects.create(
                     task = self.task,
-                    order = 2,
+                    order = 3,
                     test_case = test_case
                     )
 


### PR DESCRIPTION
Don't reuse checker order number … in same testcase `test_dejagnu_checker` .
Order number `0`, `1` are used in the same test case some lines above.
Therefor the second two components in `test_dejagnu_checker` must have order number `2`, `3` .